### PR TITLE
Fix Aspera key filename to match actual key file

### DIFF
--- a/pridepy/files/files.py
+++ b/pridepy/files/files.py
@@ -284,7 +284,7 @@ class Files:
         """
         ascp_path = Files.get_ascp_binary()
         key_full_path = importlib.resources.files("pridepy").joinpath(
-            "aspera/key/aspera_tokenauth_id_rsa"
+            "aspera/key/asperaweb_id_dsa.openssh"
         )
         key_path = os.path.abspath(key_full_path)
         for file in file_list_json:


### PR DESCRIPTION
### **User description**
## Problem
The code in `files.py` was looking for a key file named `aspera_tokenauth_id_rsa`, but the actual key file in the repository is named `asperaweb_id_dsa.openssh`. 

This mismatch caused authentication failures when users tried to download files using the Aspera protocol, resulting in password/passphrase prompts.

## Solution
Updated both occurrences in `files.py` (lines ~9 and ~172) to use the correct key filename: `asperaweb_id_dsa.openssh`

## Testing
- Tested on Linux with `pridepy download-file-by-name -a PXD004683 -f 20150820_Haura-Pilot-TMT2-bRPLC06-2.raw -o ~/pride_data/ -p aspera`
- Downloads now complete successfully without authentication prompts

## Files Changed
- `pridepy/files/files.py`: Changed key filename from `aspera_tokenauth_id_rsa` to `asperaweb_id_dsa.openssh` (2 locations)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed Aspera key filename mismatch causing authentication failures

- Updated key path from `aspera_tokenauth_id_rsa` to `asperaweb_id_dsa.openssh`

- Resolves password/passphrase prompts during Aspera protocol downloads


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Incorrect key filename<br/>aspera_tokenauth_id_rsa"] -- "Fix mismatch" --> B["Correct key filename<br/>asperaweb_id_dsa.openssh"]
  B --> C["Aspera downloads<br/>work without prompts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>files.py</strong><dd><code>Correct Aspera key filename in download method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pridepy/files/files.py

<ul><li>Updated Aspera key filename in <code>download_files_from_aspera</code> method<br> <li> Changed from <code>aspera_tokenauth_id_rsa</code> to <code>asperaweb_id_dsa.openssh</code><br> <li> Fixes authentication failures when downloading files via Aspera <br>protocol</ul>


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/pridepy/pull/72/files#diff-a841f149293bacff57c3547e07605f2675a770c627d4c4be1b549866d81c15a5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication configuration for Aspera file downloads to use the correct key credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->