### PR TITLE
improve skip options

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ pridepy download-all-public-raw-files -a PXD012353 -o /Users/yourname/Download
 
 Additional options: 
 
-- `--skip-if-downloaded-already` / `--no-skip-if-downloaded-already` flag is used to control whether to skip files that already exist in the output directory. By default, files are skipped if they already exist. Use `--no-skip-if-downloaded-already` to force re-download.
+- `--skip-if-downloaded-already` flag is used to skip files that already exist in the output directory. By default, files are re-downloaded even if they already exist. Use this flag to avoid re-downloading existing files.
 - `--aspera-maximum-bandwidth` flag is used to specify the maximum bandwidth for the Aspera download. The default value is 100M.
 - `--checksum-check` flag is used to check the checksum of the downloaded files. The default value is False.
 
@@ -93,7 +93,7 @@ $ pridepy download-px-raw-files -a PXD039236 -o /Users/yourname/Downloads/folder
 ```
 
 - The tool resolves the ProteomeXchange XML and downloads via FTP when available, otherwise HTTP(S).
-- Resume and skip-if-already-downloaded are supported by default.
+- Resume is supported. Use `--skip-if-downloaded-already` flag to skip files that have already been downloaded.
 
 ## Download single file by name
 

--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -29,10 +29,10 @@ def main():
     help="output folder to download or copy raw files",
 )
 @click.option(
-    "--skip-if-downloaded-already/--no-skip-if-downloaded-already",
+    "--skip-if-downloaded-already",
     is_flag=True,
-    default=True,
-    help="Skip the download if the file has already been downloaded. Default is to skip.",
+    default=False,
+    help="Skip the download if the file has already been downloaded.",
 )
 @click.option(
     "--aspera-maximum-bandwidth",
@@ -62,7 +62,7 @@ def download_all_public_raw_files(
         accession (str): PRIDE project accession.
         protocol (str): Protocol for downloading files (ftp, aspera, globus). Default is ftp.
         output_folder (str): Directory to save downloaded raw files.
-        skip_if_downloaded_already (bool): Skip download if files already exist. Default is True.
+        skip_if_downloaded_already (bool): Skip download if files already exist. Default is False.
         aspera_maximum_bandwidth (str): Maximum bandwidth for Aspera protocol. Default is 100M.
         checksum_check (bool): Flag to download checksum file for the project. Default is False.
     """
@@ -102,10 +102,10 @@ def download_all_public_raw_files(
     help="output folder to download or copy raw files",
 )
 @click.option(
-    "--skip-if-downloaded-already/--no-skip-if-downloaded-already",
+    "--skip-if-downloaded-already",
     is_flag=True,
-    default=True,
-    help="Skip the download if the file has already been downloaded. Default is to skip.",
+    default=False,
+    help="Skip the download if the file has already been downloaded.",
 )
 @click.option(
     "--aspera-maximum-bandwidth",
@@ -143,7 +143,7 @@ def download_all_public_category_files(
         accession (str): The PRIDE project accession identifier.
         protocol (str): The protocol to use for downloading files (ftp, aspera, globus).
         output_folder (str): The directory where the files will be downloaded.
-        skip_if_downloaded_already (bool): If True, skips downloading files that already exist.
+        skip_if_downloaded_already (bool): If True, skips downloading files that already exist. Default is False.
         aspera_maximum_bandwidth (str): Maximum bandwidth for Aspera transfers.
         checksum_check (bool): If True, downloads the checksum file for the project.
         category (str): The category of files to download.
@@ -186,10 +186,10 @@ def download_all_public_category_files(
     help="output folder to download or copy files",
 )
 @click.option(
-    "--skip-if-downloaded-already/--no-skip-if-downloaded-already",
+    "--skip-if-downloaded-already",
     is_flag=True,
-    default=True,
-    help="Skip the download if the file has already been downloaded. Default is to skip.",
+    default=False,
+    help="Skip the download if the file has already been downloaded.",
 )
 @click.option("--username", required=False, help="PRIDE login username for private files")
 @click.option("--password", required=False, help="PRIDE login password for private files")
@@ -223,7 +223,7 @@ def download_file_by_name(
     :param protocol: Protocol to be used to download files either by ftp or aspera or from globus. Default is ftp
     :param file_name: fileName to be downloaded
     :param output_folder: output folder to download or copy files
-    :param skip_if_downloaded_already: Boolean value to skip the download if the file has already been downloaded.
+    :param skip_if_downloaded_already: Boolean value to skip the download if the file has already been downloaded. Default is False.
     :param username: PRIDE login username for private files
     :param password: PRIDE login password for private files
     :param aspera_maximum_bandwidth: Aspera maximum bandwidth (e.g 50M, 100M, 200M), depending on the user's network bandwidth, default is 100M
@@ -269,10 +269,10 @@ def download_file_by_name(
     help="output folder to download files",
 )
 @click.option(
-    "--skip-if-downloaded-already/--no-skip-if-downloaded-already",
+    "--skip-if-downloaded-already",
     is_flag=True,
-    default=True,
-    help="Skip the download if the file has already been downloaded. Default is to skip.",
+    default=False,
+    help="Skip the download if the file has already been downloaded.",
 )
 def download_px_raw_files(accession: str, output_folder: str, skip_if_downloaded_already: bool):
     """CLI wrapper to download raw files via ProteomeXchange XML."""


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Convert `skip_if_downloaded_already` option to Click boolean flag

- Standardize flag naming with hyphens across all commands

- Improve help text clarity and consistency

- Update documentation with new flag usage examples


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old: -skip flag<br/>String-based option"] -- "Refactor" --> B["New: --skip-if-downloaded-already<br/>Boolean flag"]
  B -- "Applied to" --> C["4 CLI commands"]
  D["Help text<br/>inconsistencies"] -- "Standardize" --> E["Consistent help<br/>across commands"]
  F["README<br/>documentation"] -- "Update" --> G["New flag syntax<br/>and examples"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pridepy.py</strong><dd><code>Convert skip option to boolean flag format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pridepy/pridepy.py

<ul><li>Converted <code>skip_if_downloaded_already</code> from string option to boolean <br>flag in 4 CLI commands<br> <li> Changed flag syntax from <code>-skip</code> to <br><code>--skip-if-downloaded-already/--no-skip-if-downloaded-already</code><br> <li> Updated help text to be consistent: "Skip the download if the file has <br>already been downloaded. Default is to skip."<br> <li> Applied changes to <code>main()</code>, <code>download_all_public_raw_files()</code>, <br><code>download_all_public_category_files()</code>, and <code>download_px_raw_files()</code> <br>commands</ul>


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/pridepy/pull/74/files#diff-6d2444b3de21b83ffd6288dc76ad39021d24feff9847a1f26cd3dc181da9b3b4">+12/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for new skip flag syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated documentation to reflect new flag naming convention<br> <li> Added explanation of both <code>--skip-if-downloaded-already</code> and <br><code>--no-skip-if-downloaded-already</code> options<br> <li> Clarified default behavior and how to force re-download</ul>


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/pridepy/pull/74/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified download behavior and updated docs to recommend using --skip-if-downloaded-already to avoid re-downloading; notes now state resume is supported.

* **Updates**
  * CLI option names normalized to kebab-case for consistency (e.g., output-folder, file-name, page-size, sort-direction, checksum-check, aspera-maximum-bandwidth).
  * Skip behavior changed: by default files are re-downloaded; use --skip-if-downloaded-already to skip existing files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->