### PR TITLE
Support comma-separated multiple categories in download-all-public-category-files

### DIFF
--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -124,8 +124,8 @@ def download_all_public_raw_files(
     "-c",
     "--category",
     required=True,
-    help="Category of the files to be downloaded",
-    type=click.Choice("RAW,PEAK,SEARCH,RESULT,SPECTRUM_LIBRARY,OTHER,FASTA".split(",")),
+    help="Comma-separated categories of files to download (e.g. RAW or RAW,SEARCH). "
+    "Valid values: RAW, PEAK, SEARCH, RESULT, SPECTRUM_LIBRARY, OTHER, FASTA",
 )
 def download_all_public_category_files(
     accession: str,
@@ -146,8 +146,17 @@ def download_all_public_category_files(
         skip_if_downloaded_already (bool): If True, skips downloading files that already exist. Default is False.
         aspera_maximum_bandwidth (str): Maximum bandwidth for Aspera transfers.
         checksum_check (bool): If True, downloads the checksum file for the project.
-        category (str): The category of files to download.
+        category (str): Comma-separated categories of files to download (e.g. RAW or RAW,SEARCH).
     """
+
+    valid_categories = {"RAW", "PEAK", "SEARCH", "RESULT", "SPECTRUM_LIBRARY", "OTHER", "FASTA"}
+    categories = [c.strip().upper() for c in category.split(",")]
+    invalid = set(categories) - valid_categories
+    if invalid:
+        raise click.BadParameter(
+            f"Invalid category: {', '.join(invalid)}. "
+            f"Valid values: {', '.join(sorted(valid_categories))}"
+        )
 
     raw_files = Files()
     logging.info("accession: " + accession)
@@ -163,7 +172,7 @@ def download_all_public_category_files(
         protocol,
         aspera_maximum_bandwidth=aspera_maximum_bandwidth,
         checksum_check=checksum_check,
-        category=category,
+        categories=categories,
     )
 
 

--- a/pridepy/tests/test_raw_files.py
+++ b/pridepy/tests/test_raw_files.py
@@ -37,3 +37,16 @@ class TestRawFiles(TestCase):
 
         result = raw.get_all_category_file_list("PXD008644", "SEARCH")
         assert len(result) == 2
+
+    def test_get_all_category_file_list_multiple(self):
+        """
+        Test filtering by multiple categories at once.
+        PXD008644 has 2 RAW + 2 SEARCH = 4 files combined.
+        """
+        raw = Files()
+        result = raw.get_all_category_file_list("PXD008644", ["RAW", "SEARCH"])
+        assert len(result) == 4
+
+        # Verify both categories are present
+        categories = {file["fileCategory"]["value"] for file in result}
+        assert categories == {"RAW", "SEARCH"}


### PR DESCRIPTION
## Summary
- The `-c/--category` option in `download-all-public-category-files` now accepts comma-separated values (e.g. `-c RAW,SEARCH`) to download files from multiple categories in a single command
- `get_all_category_file_list()` accepts either a single category string or a list of categories
- Backward compatible: single category values (e.g. `-c RAW`) continue to work as before

## Usage
```bash
# Single category (unchanged)
pridepy download-all-public-category-files -a PXD008644 -o /out -c RAW

# Multiple categories (new)
pridepy download-all-public-category-files -a PXD008644 -o /out -c RAW,SEARCH
```

## Test plan
- [x] Existing `test_get_all_category_file_list` passes (single category still works)
- [x] New `test_get_all_category_file_list_multiple` verifies multi-category filtering returns correct files from both categories
- [x] All 6 active tests pass (`pytest pridepy/tests/ -v`)
- [ ] Verify CLI validation rejects invalid category names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for downloading files from multiple categories simultaneously.
  * Command-line interface now accepts comma-separated categories for flexible filtering.
  * Added validation with detailed error messages for invalid category inputs.

* **Tests**
  * Added test coverage for multi-category file filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->