### PR TITLE
Add resilient multi-protocol download with fallback and checksum validation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -24,9 +24,6 @@ jobs:
     - name: Install dependencies
       run: |
         uv sync --extra dev
-    - name: Build package
-      run: |
-        uv build
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -36,3 +33,6 @@ jobs:
     - name: Test with pytest
       run: |
         uv run pytest
+    - name: Build package
+      run: |
+        uv build

--- a/pridepy/files/files.py
+++ b/pridepy/files/files.py
@@ -57,6 +57,8 @@ class Files:
     API_BASE_URL = "https://www.ebi.ac.uk/pride/ws/archive/v3"
     API_PRIVATE_URL = "https://www.ebi.ac.uk/pride/private/ws/archive/v2"
     PRIDE_ARCHIVE_FTP = "ftp.pride.ebi.ac.uk"
+    PRIDE_ARCHIVE_FTP_URL_PREFIX = "ftp://ftp.pride.ebi.ac.uk/"
+    GLOBUS_BASE_URL = "https://g-a8b222.dd271.03c0.data.globus.org/"
     S3_URL = "https://hh.fire.sdo.ebi.ac.uk"
     S3_BUCKET = "pride-public"
     PROTOCOL_ORDER = ["aspera", "s3", "ftp", "globus"]
@@ -165,38 +167,54 @@ class Files:
     @staticmethod
     def _get_download_url(file_record: Dict, protocol: str) -> str:
         """
-        Resolve the best public download URL for a file and protocol.
+        Resolve the public download URL for a file and protocol.
+
+        Raises ValueError when the requested protocol has no suitable location.
+        Aspera requires a dedicated "Aspera Protocol" entry; ftp/s3/globus
+        derive their URL from the "FTP Protocol" entry (falling back to an
+        arbitrary non-Aspera location would produce a URL the caller cannot
+        actually transfer with).
         """
         locations = file_record.get("publicFileLocations", [])
         if not locations:
             raise ValueError("No public file locations present")
 
-        if protocol == "aspera":
-            for location in locations:
-                if location.get("name") == "Aspera Protocol":
-                    return location.get("value")
-            raise ValueError("Aspera URL not available")
-
-        # FTP URL exists for ftp, globus and s3 adaptation
+        aspera_url = None
         ftp_url = None
         for location in locations:
-            if location.get("name") == "FTP Protocol":
+            name = location.get("name")
+            if name == "Aspera Protocol":
+                aspera_url = location.get("value")
+            elif name == "FTP Protocol":
                 ftp_url = location.get("value")
-                break
-        if not ftp_url:
-            ftp_url = locations[0].get("value")
+
+        if protocol == "aspera":
+            if not aspera_url:
+                raise ValueError("Aspera URL not available")
+            return aspera_url
+
         if not ftp_url:
             raise ValueError("FTP URL not available")
-
         if protocol == "ftp":
             return ftp_url
         if protocol == "globus":
-            return ftp_url.replace(
-                "ftp://ftp.pride.ebi.ac.uk/", "https://g-a8b222.dd271.03c0.data.globus.org/"
-            )
+            return ftp_url.replace(Files.PRIDE_ARCHIVE_FTP_URL_PREFIX, Files.GLOBUS_BASE_URL)
         if protocol == "s3":
             return ftp_url
         raise ValueError(f"Unsupported protocol: {protocol}")
+
+    @staticmethod
+    def _resolve_local_path(file_record: Dict, output_folder: str) -> str:
+        """
+        Compute the canonical local path for a file regardless of transfer protocol.
+        """
+        try:
+            canonical_url = Files._get_download_url(file_record, "ftp")
+        except ValueError:
+            canonical_url = ""
+        if canonical_url:
+            return Files.get_output_file_name(canonical_url, file_record, output_folder)
+        return os.path.join(output_folder, file_record["fileName"])
 
     @staticmethod
     def _protocol_sequence(protocol: str) -> List[str]:
@@ -489,9 +507,9 @@ class Files:
                     download_url = file["publicFileLocations"][1]["value"]
 
                 logging.debug(f"Downloading from Globus: {download_url}")
-                ftp_base_url = "ftp://ftp.pride.ebi.ac.uk/"
-                globus_base_url = "https://g-a8b222.dd271.03c0.data.globus.org/"
-                download_url = download_url.replace(ftp_base_url, globus_base_url)
+                download_url = download_url.replace(
+                    Files.PRIDE_ARCHIVE_FTP_URL_PREFIX, Files.GLOBUS_BASE_URL
+                )
 
                 # Create a clean filename to save the downloaded file
                 new_file_path = Files.get_output_file_name(download_url, file, output_folder)
@@ -821,76 +839,65 @@ class Files:
             return output_path
 
     @staticmethod
-    def _download_one_file_by_protocol(
-        file_record: Dict,
+    def _batch_download_by_protocol(
+        file_list: List[Dict],
         output_folder: str,
         protocol: str,
+        skip_if_downloaded_already: bool,
         aspera_maximum_bandwidth: str,
     ) -> None:
         """
-        Attempt a single file transfer using one protocol.
+        Transfer a batch of files with one protocol, reusing a single
+        connection where the underlying helper supports it (FTP, S3).
         """
+        if not file_list:
+            return
         if protocol == "ftp":
             Files.download_files_from_ftp(
-                [file_record],
+                file_list,
                 output_folder,
-                skip_if_downloaded_already=False,
+                skip_if_downloaded_already=skip_if_downloaded_already,
             )
             return
         if protocol == "aspera":
             Files.download_files_from_aspera(
-                [file_record],
+                file_list,
                 output_folder,
-                skip_if_downloaded_already=False,
+                skip_if_downloaded_already=skip_if_downloaded_already,
                 maximum_bandwidth=aspera_maximum_bandwidth,
             )
             return
         if protocol == "globus":
             Files.download_files_from_globus(
-                [file_record],
+                file_list,
                 output_folder,
-                skip_if_downloaded_already=False,
+                skip_if_downloaded_already=skip_if_downloaded_already,
             )
             return
         if protocol == "s3":
             Files.download_files_from_s3(
-                [file_record],
+                file_list,
                 output_folder,
-                skip_if_downloaded_already=False,
+                skip_if_downloaded_already=skip_if_downloaded_already,
             )
             return
         raise ValueError(f"Unsupported protocol: {protocol}")
 
+    @staticmethod
     def _download_with_fallback(
-        self,
         file_record: Dict,
         output_folder: str,
-        skip_if_downloaded_already: bool,
         protocol_sequence: List[str],
         expected_checksum: Optional[str],
         aspera_maximum_bandwidth: str,
         max_protocol_retries: int = 2,
     ) -> bool:
         """
-        Download one file with automatic retries and protocol fallback.
+        Download one file by trying each protocol in sequence, validating
+        after every attempt. Intended as the per-file fallback path; batch
+        download of the primary protocol is handled separately.
         """
-        try:
-            canonical_url = Files._get_download_url(file_record, "ftp")
-        except ValueError:
-            canonical_url = file_record.get("publicFileLocations", [{}])[0].get("value", "")
-        if canonical_url:
-            local_path = Files.get_output_file_name(canonical_url, file_record, output_folder)
-        else:
-            local_path = os.path.join(output_folder, file_record["fileName"])
-
-        if skip_if_downloaded_already and os.path.exists(local_path):
-            valid, reason = Files.validate_download(local_path, expected_checksum)
-            if valid:
-                logging.info(f"Skipping already valid file: {local_path}")
-                return True
-            logging.warning(
-                f"Existing file is invalid ({reason}), re-downloading: {local_path}"
-            )
+        local_path = Files._resolve_local_path(file_record, output_folder)
 
         for protocol in protocol_sequence:
             for attempt in range(1, max_protocol_retries + 1):
@@ -900,11 +907,12 @@ class Files:
                 )
                 try:
                     Files._remove_if_exists(local_path)
-                    self._download_one_file_by_protocol(
-                        file_record,
+                    Files._batch_download_by_protocol(
+                        [file_record],
                         output_folder,
                         protocol,
-                        aspera_maximum_bandwidth,
+                        skip_if_downloaded_already=False,
+                        aspera_maximum_bandwidth=aspera_maximum_bandwidth,
                     )
                 except Exception as error:
                     logging.error(
@@ -962,16 +970,55 @@ class Files:
             checksum_map = Files.read_checksum_file(checksum_file_path)
             logging.info(f"Loaded checksums for {len(checksum_map)} files")
 
+        if not file_list_json:
+            return
+
         protocol_sequence = Files._protocol_sequence(protocol)
-        file_handler = Files()
+        primary_protocol = protocol_sequence[0]
+        fallback_sequence = protocol_sequence[1:]
+
+        # Phase 1: batch download with the requested protocol. Reuses a single
+        # FTP/S3 connection for all files (the previous behaviour) instead of
+        # paying the per-file reconnect cost in the common happy path.
+        logging.info(
+            f"Downloading {len(file_list_json)} file(s) via {primary_protocol} (batch)"
+        )
+        try:
+            Files._batch_download_by_protocol(
+                file_list_json,
+                output_folder,
+                primary_protocol,
+                skip_if_downloaded_already=skip_if_downloaded_already,
+                aspera_maximum_bandwidth=aspera_maximum_bandwidth,
+            )
+        except Exception as exc:
+            logging.warning(
+                f"Batch {primary_protocol} run hit an error; will retry individual failures: {exc}"
+            )
+
+        # Phase 2: validate every file and fall back per-file for the ones
+        # that are missing or invalid.
         failed_files: List[str] = []
         for file_record in file_list_json:
             expected_checksum = checksum_map.get(file_record["fileName"])
-            success = file_handler._download_with_fallback(
+            local_path = Files._resolve_local_path(file_record, output_folder)
+            valid, reason = Files.validate_download(local_path, expected_checksum)
+            if valid:
+                continue
+
+            logging.warning(
+                f"{file_record['fileName']} invalid after {primary_protocol} ({reason})"
+            )
+            Files._remove_if_exists(local_path)
+
+            if not fallback_sequence:
+                failed_files.append(file_record.get("fileName", "<unknown>"))
+                continue
+
+            success = Files._download_with_fallback(
                 file_record=file_record,
                 output_folder=output_folder,
-                skip_if_downloaded_already=skip_if_downloaded_already,
-                protocol_sequence=protocol_sequence,
+                protocol_sequence=fallback_sequence,
                 expected_checksum=expected_checksum,
                 aspera_maximum_bandwidth=aspera_maximum_bandwidth,
             )

--- a/pridepy/tests/test_download_resilience.py
+++ b/pridepy/tests/test_download_resilience.py
@@ -43,10 +43,11 @@ class TestDownloadResilience(TestCase):
         assert Files._protocol_sequence("aspera") == ["aspera", "s3", "ftp", "globus"]
 
     def test_download_with_fallback_switches_protocol_after_invalid_file(self):
-        handler = Files()
         file_record = {
             "fileName": "sample.raw",
-            "publicFileLocations": [{"name": "FTP Protocol", "value": "ftp://ftp.pride.ebi.ac.uk/p.raw"}],
+            "publicFileLocations": [
+                {"name": "FTP Protocol", "value": "ftp://ftp.pride.ebi.ac.uk/p.raw"}
+            ],
         }
         expected_checksum = hashlib.md5(b"abc").hexdigest()
 
@@ -54,7 +55,8 @@ class TestDownloadResilience(TestCase):
             local_path = os.path.join(tmp_dir, "p.raw")
             attempted_protocols = []
 
-            def fake_download(record, output_folder, protocol, aspera_bandwidth):
+            def fake_batch(file_list, output_folder, protocol, skip_if_downloaded_already,
+                           aspera_maximum_bandwidth):
                 attempted_protocols.append(protocol)
                 if protocol == "aspera":
                     with open(local_path, "wb") as handle:
@@ -63,11 +65,10 @@ class TestDownloadResilience(TestCase):
                     with open(local_path, "wb") as handle:
                         handle.write(b"abc")
 
-            with patch.object(Files, "_download_one_file_by_protocol", side_effect=fake_download):
-                success = handler._download_with_fallback(
+            with patch.object(Files, "_batch_download_by_protocol", side_effect=fake_batch):
+                success = Files._download_with_fallback(
                     file_record=file_record,
                     output_folder=tmp_dir,
-                    skip_if_downloaded_already=False,
                     protocol_sequence=["aspera", "s3"],
                     expected_checksum=expected_checksum,
                     aspera_maximum_bandwidth="100M",
@@ -77,11 +78,46 @@ class TestDownloadResilience(TestCase):
             assert success is True
             assert attempted_protocols == ["aspera", "s3"]
 
+    def test_download_files_batch_first_skips_fallback_on_success(self):
+        """
+        When the primary-protocol batch produces valid files, the per-file
+        fallback path must not be invoked.
+        """
+        file_record = {
+            "fileName": "happy.raw",
+            "publicFileLocations": [
+                {"name": "FTP Protocol", "value": "ftp://ftp.pride.ebi.ac.uk/happy.raw"}
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            local_path = os.path.join(tmp_dir, "happy.raw")
+
+            def fake_batch(file_list, output_folder, protocol, skip_if_downloaded_already,
+                           aspera_maximum_bandwidth):
+                with open(local_path, "wb") as handle:
+                    handle.write(b"data")
+
+            with patch.object(Files, "_batch_download_by_protocol", side_effect=fake_batch) as batch_mock, \
+                 patch.object(Files, "_download_with_fallback") as fallback_mock:
+                Files.download_files(
+                    file_list_json=[file_record],
+                    accession="PXD000000",
+                    output_folder=tmp_dir,
+                    skip_if_downloaded_already=False,
+                    protocol="ftp",
+                )
+
+            assert batch_mock.call_count == 1
+            assert batch_mock.call_args.args[2] == "ftp"
+            fallback_mock.assert_not_called()
+
     def test_download_files_raises_when_any_file_fails(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             file_list = [{"fileName": "missing.raw"}]
 
-            with patch.object(Files, "_download_with_fallback", return_value=False):
+            with patch.object(Files, "_batch_download_by_protocol"), \
+                 patch.object(Files, "_download_with_fallback", return_value=False):
                 with self.assertRaisesRegex(RuntimeError, "missing.raw"):
                     Files.download_files(
                         file_list_json=file_list,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.13"
 description = "Python Client library for PRIDE Rest API"
 readme = "README.md"
 requires-python = ">=3.9"
-license = "Apache-2.0"
+license = { text = "Apache-2.0" }
 authors = [
     { name = "PRIDE Team", email = "pride-support@ebi.ac.uk" },
 ]
@@ -22,11 +22,13 @@ keywords = [
 ]
 classifiers = [
     "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Development Status :: 5 - Production/Stable",
 ]
@@ -35,8 +37,8 @@ dependencies = [
     "ratelimit>=2.2.1",
     "click>=8.1.7",
     "tqdm>=4.66.1",
-    "boto3>=1.34.0",
-    "botocore>=1.34.0",
+    "boto3>=1.34.61",
+    "botocore>=1.34.74",
     "httpx>=0.27.0",
 ]
 


### PR DESCRIPTION
## Summary

This PR introduces a robust, resilient download system for PRIDE files that automatically falls back across multiple protocols (FTP, Aspera, S3, Globus) when downloads fail or are invalid. It adds comprehensive checksum validation, improves error handling, and refactors the download logic to prioritize batch efficiency while maintaining per-file reliability.

## Key Changes

### Core Download Resilience
- **Multi-protocol fallback**: Downloads now attempt the requested protocol first, then automatically fall back to alternative protocols (aspera → s3 → globus) if validation fails
- **Checksum validation**: Added `compute_md5()`, `validate_download()`, and `read_checksum_file()` methods to verify file integrity after download
- **Two-phase download strategy**:
  - Phase 1: Batch download with primary protocol (reuses single connection for efficiency)
  - Phase 2: Per-file validation and fallback for any failures

### New Utility Methods
- `_parse_checksum_line()`: Parses common checksum file formats (md5 path, path\tmd5, md5\tpath)
- `read_checksum_file()`: Builds a checksum map from TSV/TXT files
- `compute_md5()`: Computes MD5 checksums with proper handling of older Python versions
- `validate_download()`: Checks file existence, non-empty status, and optional checksum match
- `_get_download_url()`: Resolves protocol-specific download URLs from file metadata
- `_resolve_local_path()`: Computes canonical local paths independent of transfer protocol
- `_protocol_sequence()`: Builds ordered fallback sequence for a requested protocol
- `_batch_download_by_protocol()`: Routes batch downloads to appropriate protocol handler
- `_download_with_fallback()`: Implements per-file retry logic across protocol sequence
- `_remove_if_exists()`: Safely removes incomplete/invalid files before retry

### Configuration & Constants
- Added `PROTOCOL_ORDER = ["aspera", "s3", "ftp", "globus"]` for consistent fallback ordering
- Added `PRIDE_ARCHIVE_FTP_URL_PREFIX` and `GLOBUS_BASE_URL` constants
- Added `V3_API_BASE_URL` constant for checksum endpoint

### Enhanced `download_files()` Method
- Now orchestrates batch + fallback strategy instead of simple protocol dispatch
- Loads and applies checksums when `checksum_check=True`
- Validates all files after batch download and retries failures
- Raises `RuntimeError` with detailed failure summary if any files cannot be downloaded
- Creates output folder if it doesn't exist

### Bug Fixes & Improvements
- Fixed `get_output_file_name()` to safely handle missing "accession" field
- Updated `save_checksum_file()` to return the checksum file path and use UTF-8 encoding
- Replaced hardcoded URLs with class constants in `download_files_from_globus()`

### Testing
- Added comprehensive test suite (`test_download_resilience.py`) covering:
  - Checksum file parsing in multiple formats
  - Empty and corrupted file detection
  - Protocol sequence generation
  - Fallback behavior on validation failure
  - Batch-first strategy (no fallback on success)
  - Error raising on complete failure

### Build & Development
- Migrated from Poetry to setuptools/uv for dependency management
- Updated `pyproject.toml` to PEP 621 format
- Updated CI/CD workflows to use `uv` instead of Poetry
- Added `.flake8` configuration file
- Updated Python version support: 3.9, 3.10, 3.11, 3.12
- Improved README with quick-start examples and clearer documentation

## Implementation Details

The download system now works as follows:

1. **Batch Phase**: All files are downloaded using the requested protocol with a single connection
2. **Validation Phase**: Each file is checked for existence, non-empty status, and checksum match
3. **Fallback Phase**: Failed files are retried individually across the remaining protocols
4. **Error Reporting**: If any file cannot be downloaded after all protocols are exhausted,

https://claude.ai/code/session_01V9mHYkhG1pggyzJCii8do3