### PR TITLE
Enhance CLI with file download features and options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ venv
 #Ignore cursor AI rules
 .cursor/rules/codacy.mdc
 .DS_Store
+
+# Docker
+Dockerfile
+.dockerignore

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ pridepy download-files-by-url \
 
 `urls.txt` is one fully-qualified URL per line. Schemes `http`, `https`, and
 `ftp` are dispatched to the matching downloader. Use `--url <single>` for a
-single URL.
+single URL, or `--urls a,b,c` for an inline comma-separated list (URLs are
+RFC 3986 compliant and never contain commas).
 
 ## CLI Command Overview
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,34 @@ pridepy download-px-raw-files \
   -o ./downloads/PXD039236
 ```
 
+### 6) Download a named subset of files (manifest)
+
+```bash
+pridepy download-files-by-list \
+  -a PXD001819 \
+  -F files.txt \
+  -o ./downloads/PXD001819 \
+  --checksum-check
+```
+
+`files.txt` is one filename per line (blank lines and `#` comments are
+ignored). Internally each filename is resolved against the project metadata
+API and downloaded via the same batch + protocol-fallback engine as
+`download-all-public-raw-files`. Use `-f a.raw,b.raw,c.raw` instead of
+`-F` for a small inline list.
+
+### 7) Download files from raw URLs
+
+```bash
+pridepy download-files-by-url \
+  -F urls.txt \
+  -o ./downloads/urls
+```
+
+`urls.txt` is one fully-qualified URL per line. Schemes `http`, `https`, and
+`ftp` are dispatched to the matching downloader. Use `--url <single>` for a
+single URL.
+
 ## CLI Command Overview
 
 ```bash
@@ -116,6 +144,8 @@ Main commands:
 - `download-all-public-raw-files`
 - `download-all-public-category-files`
 - `download-file-by-name`
+- `download-files-by-list`
+- `download-files-by-url`
 - `download-px-raw-files`
 - `list-private-files`
 - `stream-files-metadata`

--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ pridepy download-files-by-url \
 
 `urls.txt` is one fully-qualified URL per line. Schemes `http`, `https`, and
 `ftp` are dispatched to the matching downloader. Use `-u/--urls` for one or
-more comma-separated URLs (URLs are RFC 3986 compliant and never contain
-commas), e.g. `--urls https://a.com/x.raw,ftp://b.com/y.raw`.
+more comma-separated URLs, e.g. `--urls https://a.com/x.raw,ftp://b.com/y.raw`.
+Note: URLs containing literal commas are not supported with `--urls`; use a
+manifest file (`-F`) instead.
 
 Useful options:
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ API and downloaded via the same batch + protocol-fallback engine as
 `download-all-public-raw-files`. Use `-f a.raw,b.raw,c.raw` instead of
 `-F` for a small inline list.
 
+Useful options:
+
+- `-p globus` — use the globus download strategy (HTTP Range + resume)
+- `-w 3` — download up to 3 files in parallel (globus only, max 3)
+- `--checksum-check` — validate files against PRIDE checksums after download
+
 ### 7) Download files from raw URLs
 
 ```bash
@@ -131,9 +137,16 @@ pridepy download-files-by-url \
 ```
 
 `urls.txt` is one fully-qualified URL per line. Schemes `http`, `https`, and
-`ftp` are dispatched to the matching downloader. Use `--url <single>` for a
-single URL, or `--urls a,b,c` for an inline comma-separated list (URLs are
-RFC 3986 compliant and never contain commas).
+`ftp` are dispatched to the matching downloader. Use `-u/--urls` for one or
+more comma-separated URLs (URLs are RFC 3986 compliant and never contain
+commas), e.g. `--urls https://a.com/x.raw,ftp://b.com/y.raw`.
+
+Useful options:
+
+- `-p globus` — use globus download strategy for http/https URLs (resume-capable)
+- `-w 3` — download up to 3 files in parallel (globus only, max 3)
+- `--checksum-check` — validate against PRIDE checksums (accession inferred
+  from PRIDE URL paths; only PRIDE archive URLs are supported)
 
 ## CLI Command Overview
 

--- a/pridepy/files/files.py
+++ b/pridepy/files/files.py
@@ -512,7 +512,7 @@ class Files:
                 time.sleep(2 * attempt)
 
     @staticmethod
-    def _parallel_download(url, file_path):
+    def _parallel_download(url, file_path, position=0):
         """Download a file using parallel Range requests, like browser parallel downloading.
         Supports resume: if a partial file exists, continues from where it left off."""
         session = Util.create_session_with_retries()
@@ -539,7 +539,7 @@ class Files:
         with session.get(url, headers=headers, stream=True, timeout=(30, 60)) as r:
             r.raise_for_status()
             with tqdm(total=total_size, unit="B", unit_scale=True, desc=file_path,
-                      initial=resume_size) as pbar:
+                      initial=resume_size, position=position, leave=True) as pbar:
                 mode = "ab" if resume_size > 0 else "wb"
                 with open(file_path, mode, buffering=8 * 1024 * 1024) as f:
                     for chunk in r.iter_content(chunk_size=8 * 1024 * 1024):
@@ -548,7 +548,7 @@ class Files:
                             pbar.update(len(chunk))
 
     @staticmethod
-    def _globus_download_one(file, output_folder, skip_if_downloaded_already, max_retries=6):
+    def _globus_download_one(file, output_folder, skip_if_downloaded_already, max_retries=6, position=0):
         """Download a single file via globus; used as a worker target."""
         download_url = Files._get_download_url(file, "globus")
         new_file_path = Files.get_output_file_name(download_url, file, output_folder)
@@ -559,7 +559,7 @@ class Files:
 
         for attempt in range(1, max_retries + 1):
             try:
-                Files._parallel_download(download_url, new_file_path)
+                Files._parallel_download(download_url, new_file_path, position=position)
                 return
             except Exception as e:
                 logging.warning(f"Attempt {attempt}/{max_retries} failed for {file.get('fileName', '?')}: {e}")
@@ -638,8 +638,9 @@ class Files:
                     executor.submit(
                         Files._globus_download_one,
                         file, output_folder, False,
+                        position=idx,
                     ): file
-                    for file in files_to_download
+                    for idx, file in enumerate(files_to_download)
                 }
                 for future in as_completed(futures):
                     try:
@@ -1162,6 +1163,7 @@ class Files:
         protocol: str = "ftp",
         aspera_maximum_bandwidth: str = "100M",
         checksum_check: bool = False,
+        parallel_files: int = 1,
     ) -> None:
         """Download a subset of project files identified by a filename list.
 
@@ -1176,6 +1178,7 @@ class Files:
         :param protocol: preferred protocol; falls back across others on failure
         :param aspera_maximum_bandwidth: aspera ascp bandwidth cap
         :param checksum_check: download project checksums and validate
+        :param parallel_files: number of files to download simultaneously for globus
         :raises ValueError: if ``file_names`` is empty or none match the project
         """
         if not file_names:
@@ -1200,7 +1203,19 @@ class Files:
             protocol,
             aspera_maximum_bandwidth=aspera_maximum_bandwidth,
             checksum_check=checksum_check,
+            parallel_files=parallel_files,
         )
+
+    @staticmethod
+    def _extract_pride_accession(url: str) -> Optional[str]:
+        """Extract a PRIDE accession (PXD/PRD followed by digits) from a URL path.
+
+        PRIDE archive URLs follow the pattern
+        ``…/pride/data/archive/YYYY/MM/<ACCESSION>/filename``.
+        Returns ``None`` when no accession can be identified.
+        """
+        match = re.search(r"((?:PXD|PRD)\d{4,})", url)
+        return match.group(1) if match else None
 
     @staticmethod
     def download_files_by_url(
@@ -1208,6 +1223,8 @@ class Files:
         output_folder: str,
         skip_if_downloaded_already: bool = False,
         protocol: str = "ftp",
+        parallel_files: int = 1,
+        checksum_check: bool = False,
     ) -> None:
         """Download files from a list of raw URLs, dispatched by URL scheme.
 
@@ -1222,6 +1239,8 @@ class Files:
         :param protocol: ``ftp`` (default) for single-connection per URL scheme;
             ``globus`` for parallel multi-Range downloads on http/https URLs
             (no effect on ftp:// URLs which always use single-connection FTP)
+        :param checksum_check: validate downloads against PRIDE checksum API;
+            accessions are inferred from URL paths (only PRIDE URLs supported)
         :raises ValueError: if ``urls`` is empty
         :raises RuntimeError: if one or more URLs failed
         """
@@ -1230,20 +1249,92 @@ class Files:
 
         os.makedirs(output_folder, exist_ok=True)
 
+        parallel_files = min(parallel_files, 3)
         failures: List[Tuple[str, str]] = []
-        for url in urls:
-            try:
-                Files._download_single_url(
-                    url, output_folder, skip_if_downloaded_already, protocol,
-                )
-            except Exception as exc:  # pylint: disable=broad-except
-                logging.error("Failed to download %s: %s", url, exc)
-                failures.append((url, str(exc)))
+        if parallel_files < 2:
+            for url in urls:
+                try:
+                    Files._download_single_url(
+                        url, output_folder, skip_if_downloaded_already, protocol,
+                    )
+                except Exception as exc:  # pylint: disable=broad-except
+                    logging.error("Failed to download %s: %s", url, exc)
+                    failures.append((url, str(exc)))
+        else:
+            logging.info(
+                "Downloading %d URL(s) with %d parallel workers",
+                len(urls), parallel_files,
+            )
+            with ThreadPoolExecutor(max_workers=parallel_files) as executor:
+                futures = {
+                    executor.submit(
+                        Files._download_single_url,
+                        url, output_folder, skip_if_downloaded_already, protocol,
+                        position=idx,
+                    ): url
+                    for idx, url in enumerate(urls)
+                }
+                for future in as_completed(futures):
+                    url = futures[future]
+                    try:
+                        future.result()
+                    except Exception as exc:  # pylint: disable=broad-except
+                        logging.error("Failed to download %s: %s", url, exc)
+                        failures.append((url, str(exc)))
 
         if failures:
             summary = ", ".join(f"{u} ({e})" for u, e in failures)
             raise RuntimeError(
                 f"Failed to download {len(failures)} URL(s): {summary}"
+            )
+
+        if checksum_check:
+            Files._validate_urls_checksums(urls, output_folder)
+
+    @staticmethod
+    def _validate_urls_checksums(urls: List[str], output_folder: str) -> None:
+        """Validate downloaded files against PRIDE checksum API.
+
+        Accessions are inferred from URL paths via
+        :meth:`_extract_pride_accession`.  URLs that do not contain a
+        recognisable PRIDE accession are skipped with a warning.
+
+        :raises RuntimeError: if one or more files fail validation
+        """
+        accession_urls: Dict[str, List[str]] = {}
+        for url in urls:
+            acc = Files._extract_pride_accession(url)
+            if acc:
+                accession_urls.setdefault(acc, []).append(url)
+            else:
+                logging.warning(
+                    "Cannot infer PRIDE accession from URL, skipping checksum: %s", url
+                )
+
+        validation_failures: List[str] = []
+        for acc, acc_urls in accession_urls.items():
+            checksum_file_path = Files.save_checksum_file(acc, output_folder)
+            checksum_map = Files.read_checksum_file(checksum_file_path)
+            logging.info(
+                "Loaded checksums for %d files (project %s)",
+                len(checksum_map), acc,
+            )
+            for url in acc_urls:
+                file_name = os.path.basename(urlparse(url).path)
+                target = os.path.join(output_folder, file_name)
+                expected = checksum_map.get(file_name)
+                logging.info("Validating %s", file_name)
+                valid, reason = Files.validate_download(target, expected)
+                if not valid:
+                    logging.error("Validation failed for %s: %s", file_name, reason)
+                    validation_failures.append(f"{file_name} ({reason})")
+                else:
+                    logging.info("Checksum OK: %s", file_name)
+
+        if validation_failures:
+            raise RuntimeError(
+                f"Checksum validation failed for {len(validation_failures)} file(s): "
+                + ", ".join(validation_failures)
             )
 
     @staticmethod
@@ -1252,6 +1343,7 @@ class Files:
         output_folder: str,
         skip_if_exists: bool = False,
         protocol: str = "ftp",
+        position: int = 0,
     ) -> str:
         """Download one URL, dispatched by scheme; return the local file path."""
         parsed = urlparse(url)
@@ -1267,7 +1359,7 @@ class Files:
             logging.info("Skipping %s: already downloaded", file_name)
             return target
 
-        Files._dispatch_url_scheme(parsed, target, protocol)
+        Files._dispatch_url_scheme(parsed, target, protocol, position=position)
 
         ok, reason = Files.validate_download(target)
         if not ok:
@@ -1276,7 +1368,7 @@ class Files:
         return target
 
     @staticmethod
-    def _dispatch_url_scheme(parsed, target: str, protocol: str = "ftp") -> None:
+    def _dispatch_url_scheme(parsed, target: str, protocol: str = "ftp", position: int = 0) -> None:
         """Route a parsed URL to its protocol-specific downloader.
 
         ``protocol='globus'`` swaps the http/https single-connection streamer
@@ -1286,7 +1378,7 @@ class Files:
         scheme = (parsed.scheme or "").lower()
         if scheme in ("http", "https"):
             if protocol == "globus":
-                Files._parallel_download(parsed.geturl(), target)
+                Files._parallel_download(parsed.geturl(), target, position=position)
             else:
                 Files._http_download_url(parsed.geturl(), target)
         elif scheme == "ftp":

--- a/pridepy/files/files.py
+++ b/pridepy/files/files.py
@@ -1092,6 +1092,180 @@ class Files:
             logging.error(f"Failed to download {len(failed_files)} file(s): {failed_summary}")
             raise RuntimeError(f"Failed to download {len(failed_files)} file(s): {failed_summary}")
 
+    def download_files_by_list(
+        self,
+        accession: str,
+        file_names: List[str],
+        output_folder: str,
+        skip_if_downloaded_already: bool,
+        protocol: str = "ftp",
+        aspera_maximum_bandwidth: str = "100M",
+        checksum_check: bool = False,
+    ) -> None:
+        """Download a subset of project files identified by a filename list.
+
+        Resolves each requested filename via the project metadata API and
+        delegates to :meth:`download_files` so the existing batch + protocol
+        fallback engine is reused.
+
+        :param accession: PRIDE project accession (public)
+        :param file_names: filenames to download
+        :param output_folder: directory to write downloaded files into
+        :param skip_if_downloaded_already: skip files already present locally
+        :param protocol: preferred protocol; falls back across others on failure
+        :param aspera_maximum_bandwidth: aspera ascp bandwidth cap
+        :param checksum_check: download project checksums and validate
+        :raises ValueError: if ``file_names`` is empty or none match the project
+        """
+        if not file_names:
+            raise ValueError("file_names must contain at least one filename")
+
+        all_files = self.stream_all_files_by_project(accession)
+        requested = set(file_names)
+        matched = [f for f in all_files if f.get("fileName") in requested]
+        missing = sorted(requested - {f.get("fileName") for f in matched})
+        if missing:
+            logging.warning("Files not found in project %s: %s", accession, missing)
+        if not matched:
+            raise ValueError(
+                f"No matching files in project {accession} for: {sorted(requested)}"
+            )
+
+        self.download_files(
+            matched,
+            accession,
+            output_folder,
+            skip_if_downloaded_already,
+            protocol,
+            aspera_maximum_bandwidth=aspera_maximum_bandwidth,
+            checksum_check=checksum_check,
+        )
+
+    @staticmethod
+    def download_files_by_url(
+        urls: List[str],
+        output_folder: str,
+        skip_if_downloaded_already: bool = False,
+    ) -> None:
+        """Download files from a list of raw URLs, dispatched by URL scheme.
+
+        Supported schemes: ``http``, ``https``, ``ftp``. Each URL is downloaded
+        independently; per-URL errors are logged, then aggregated and re-raised
+        as a single :class:`RuntimeError` so callers see a complete failure
+        summary.
+
+        :param urls: fully-qualified URLs (each contains its scheme)
+        :param output_folder: directory to write downloaded files into
+        :param skip_if_downloaded_already: skip URLs whose target file exists
+        :raises ValueError: if ``urls`` is empty
+        :raises RuntimeError: if one or more URLs failed
+        """
+        if not urls:
+            raise ValueError("urls must contain at least one URL")
+
+        os.makedirs(output_folder, exist_ok=True)
+
+        failures: List[Tuple[str, str]] = []
+        for url in urls:
+            try:
+                Files._download_single_url(url, output_folder, skip_if_downloaded_already)
+            except Exception as exc:  # pylint: disable=broad-except
+                logging.error("Failed to download %s: %s", url, exc)
+                failures.append((url, str(exc)))
+
+        if failures:
+            summary = ", ".join(f"{u} ({e})" for u, e in failures)
+            raise RuntimeError(
+                f"Failed to download {len(failures)} URL(s): {summary}"
+            )
+
+    @staticmethod
+    def _download_single_url(
+        url: str,
+        output_folder: str,
+        skip_if_exists: bool = False,
+    ) -> str:
+        """Download one URL, dispatched by scheme; return the local file path."""
+        parsed = urlparse(url)
+        if not (parsed.scheme or "").lower():
+            raise ValueError(f"URL missing scheme: {url}")
+
+        file_name = os.path.basename(parsed.path)
+        if not file_name:
+            raise ValueError(f"Cannot derive filename from URL: {url}")
+
+        target = os.path.join(output_folder, file_name)
+        if skip_if_exists and os.path.isfile(target) and os.path.getsize(target) > 0:
+            logging.info("Skipping %s: already downloaded", file_name)
+            return target
+
+        Files._dispatch_url_scheme(parsed, target)
+
+        ok, reason = Files.validate_download(target)
+        if not ok:
+            Files._remove_if_exists(target)
+            raise RuntimeError(f"Download invalid: {reason} ({target})")
+        return target
+
+    @staticmethod
+    def _dispatch_url_scheme(parsed, target: str) -> None:
+        """Route a parsed URL to its protocol-specific downloader."""
+        scheme = (parsed.scheme or "").lower()
+        if scheme in ("http", "https"):
+            Files._http_download_url(parsed.geturl(), target)
+        elif scheme == "ftp":
+            Files._ftp_download_url(parsed, target)
+        else:
+            raise ValueError(f"Unsupported URL scheme: {scheme}")
+
+    @staticmethod
+    def _http_download_url(url: str, target: str) -> None:
+        """Stream an http/https URL into ``target`` with a progress bar."""
+        session = Util.create_session_with_retries()
+        with session.get(url, stream=True, timeout=60) as response:
+            response.raise_for_status()
+            total = int(response.headers.get("Content-Length", 0))
+            with open(target, "wb") as out, tqdm(
+                total=total,
+                unit="B",
+                unit_scale=True,
+                desc=os.path.basename(target),
+            ) as pbar:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        out.write(chunk)
+                        pbar.update(len(chunk))
+
+    @staticmethod
+    def _ftp_download_url(parsed, target: str) -> None:
+        """Download a single file from an ftp:// URL with a progress bar."""
+        host = parsed.hostname
+        if not host:
+            raise ValueError(f"FTP URL missing host: {parsed.geturl()}")
+        port = parsed.port or 21
+        user = parsed.username or "anonymous"
+        pwd = parsed.password or "anonymous@"
+        remote_path = parsed.path
+        with FTP() as ftp:
+            ftp.connect(host, port, timeout=60)
+            ftp.login(user, pwd)
+            try:
+                total = ftp.size(remote_path) or 0
+            except ftplib.error_perm:
+                total = 0
+            with open(target, "wb") as out, tqdm(
+                total=total,
+                unit="B",
+                unit_scale=True,
+                desc=os.path.basename(target),
+            ) as pbar:
+
+                def _callback(data: bytes) -> None:
+                    out.write(data)
+                    pbar.update(len(data))
+
+                ftp.retrbinary(f"RETR {remote_path}", _callback)
+
     def download_all_category_files(
         self,
         accession: str,

--- a/pridepy/files/files.py
+++ b/pridepy/files/files.py
@@ -269,6 +269,7 @@ class Files:
         protocol,
         aspera_maximum_bandwidth: str,
         checksum_check: bool = False,
+        parallel_files: int = 1,
     ):
         """
         This method will download all the raw files from PRIDE PROJECT
@@ -294,6 +295,7 @@ class Files:
             protocol,
             aspera_maximum_bandwidth=aspera_maximum_bandwidth,
             checksum_check=checksum_check,
+            parallel_files=parallel_files,
         )
 
     @staticmethod
@@ -481,27 +483,38 @@ class Files:
                 logging.error(f"Aspera download failed for {new_file_path}: {str(e)}")
 
     @staticmethod
-    def _download_range(url, file_path, start, end, pbar):
+    def _download_range(url, file_path, start, end, pbar, max_retries=3):
         """Download a byte range directly into the target file using seek."""
-        session = Util.create_session_with_retries()
-        headers = {"Range": f"bytes={start}-{end}"}
-        with session.get(url, headers=headers, stream=True, timeout=(30, 300)) as r:
-            r.raise_for_status()
-            if r.status_code != 206:
-                raise RuntimeError(f"Server did not honor Range request: {r.status_code}")
-            content_range = r.headers.get("Content-Range", "")
-            if not content_range.lower().startswith(f"bytes {start}-{end}/"):
-                raise RuntimeError(f"Unexpected Content-Range header: {content_range}")
-            with open(file_path, "r+b") as f:
-                f.seek(start)
-                for chunk in r.iter_content(chunk_size=8 * 1024 * 1024):
-                    if chunk:
-                        f.write(chunk)
-                        pbar.update(len(chunk))
+        for attempt in range(1, max_retries + 1):
+            try:
+                session = Util.create_session_with_retries()
+                headers = {"Range": f"bytes={start}-{end}"}
+                with session.get(url, headers=headers, stream=True, timeout=(15, 15)) as r:
+                    r.raise_for_status()
+                    if r.status_code != 206:
+                        raise RuntimeError(f"Server did not honor Range request: {r.status_code}")
+                    content_range = r.headers.get("Content-Range", "")
+                    if not content_range.lower().startswith(f"bytes {start}-{end}/"):
+                        raise RuntimeError(f"Unexpected Content-Range header: {content_range}")
+                    with open(file_path, "r+b") as f:
+                        f.seek(start)
+                        for chunk in r.iter_content(chunk_size=8 * 1024 * 1024):
+                            if chunk:
+                                f.write(chunk)
+                                pbar.update(len(chunk))
+                return
+            except (requests.RequestException, RuntimeError, OSError) as exc:
+                logging.warning(
+                    f"Range {start}-{end} attempt {attempt}/{max_retries} failed: {exc}"
+                )
+                if attempt >= max_retries:
+                    raise
+                time.sleep(2 * attempt)
 
     @staticmethod
-    def _parallel_download(url, file_path, num_connections=8):
-        """Download a file using parallel Range requests, like browser parallel downloading."""
+    def _parallel_download(url, file_path):
+        """Download a file using parallel Range requests, like browser parallel downloading.
+        Supports resume: if a partial file exists, continues from where it left off."""
         session = Util.create_session_with_retries()
         try:
             head = session.head(url, timeout=(30, 30))
@@ -513,92 +526,126 @@ class Files:
             total_size = 0
             accept_ranges = "none"
 
-        if total_size == 0 or accept_ranges != "bytes" or num_connections < 2:
-            logging.info(
-                "Server does not support Range requests, falling back to single connection"
-            )
-            with session.get(url, stream=True, timeout=(30, 300)) as r:
-                r.raise_for_status()
-                with tqdm(total=total_size, unit="B", unit_scale=True, desc=file_path) as pbar:
-                    with open(file_path, "wb", buffering=8 * 1024 * 1024) as f:
-                        for chunk in r.iter_content(chunk_size=8 * 1024 * 1024):
-                            if chunk:
-                                f.write(chunk)
-                                pbar.update(len(chunk))
+        resume_size = 0
+        if os.path.exists(file_path) and accept_ranges == "bytes" and total_size > 0:
+            resume_size = os.path.getsize(file_path)
+            if resume_size >= total_size:
+                logging.info(f"File already complete: {file_path}")
+                return
+            if resume_size > 0:
+                logging.info(f"Resuming download from {resume_size} bytes: {file_path}")
+
+        headers = {"Range": f"bytes={resume_size}-"} if resume_size > 0 else {}
+        with session.get(url, headers=headers, stream=True, timeout=(30, 60)) as r:
+            r.raise_for_status()
+            with tqdm(total=total_size, unit="B", unit_scale=True, desc=file_path,
+                      initial=resume_size) as pbar:
+                mode = "ab" if resume_size > 0 else "wb"
+                with open(file_path, mode, buffering=8 * 1024 * 1024) as f:
+                    for chunk in r.iter_content(chunk_size=8 * 1024 * 1024):
+                        if chunk:
+                            f.write(chunk)
+                            pbar.update(len(chunk))
+
+    @staticmethod
+    def _globus_download_one(file, output_folder, skip_if_downloaded_already, max_retries=6):
+        """Download a single file via globus; used as a worker target."""
+        download_url = Files._get_download_url(file, "globus")
+        new_file_path = Files.get_output_file_name(download_url, file, output_folder)
+
+        if skip_if_downloaded_already and os.path.exists(new_file_path):
+            logging.info(f"Skipping download as file already exists: {new_file_path}")
             return
 
-        num_connections = min(num_connections, total_size)
-        chunk_size = (total_size + num_connections - 1) // num_connections
-        ranges = []
-        for start in range(0, total_size, chunk_size):
-            end = min(start + chunk_size - 1, total_size - 1)
-            ranges.append((start, end))
-
-        logging.info(
-            f"Parallel download: {num_connections} connections, "
-            f"{total_size / 1024 / 1024:.0f}MB total"
-        )
-
-        with open(file_path, "wb") as f:
-            f.seek(total_size - 1)
-            f.write(b"\0")
-
-        try:
-            with tqdm(total=total_size, unit="B", unit_scale=True, desc=file_path) as pbar:
-                with ThreadPoolExecutor(max_workers=num_connections) as executor:
-                    futures = []
-                    for start, end in ranges:
-                        f = executor.submit(
-                            Files._download_range, url, file_path, start, end, pbar
-                        )
-                        futures.append(f)
-
-                    for f in as_completed(futures):
-                        f.result()
-        except Exception as exc:
-            logging.info(f"Parallel download failed, retrying with single connection: {exc}")
-            Files._remove_if_exists(file_path)
-            with session.get(url, stream=True, timeout=(30, 300)) as r:
-                r.raise_for_status()
-                with tqdm(total=total_size, unit="B", unit_scale=True, desc=file_path) as pbar:
-                    with open(file_path, "wb", buffering=8 * 1024 * 1024) as f:
-                        for chunk in r.iter_content(chunk_size=8 * 1024 * 1024):
-                            if chunk:
-                                f.write(chunk)
-                                pbar.update(len(chunk))
+        for attempt in range(1, max_retries + 1):
+            try:
+                Files._parallel_download(download_url, new_file_path)
+                return
+            except Exception as e:
+                logging.warning(f"Attempt {attempt}/{max_retries} failed for {file.get('fileName', '?')}: {e}")
+                if attempt == max_retries:
+                    raise
 
     @staticmethod
     def download_files_from_globus(
-        file_list_json: List[Dict], output_folder, skip_if_downloaded_already
+        file_list_json: List[Dict], output_folder, skip_if_downloaded_already,
+        parallel_files: int = 1,
+        checksum_map: Optional[Dict[str, str]] = None,
     ):
         """
-        Download files using globus transfer url with progress bar for each file
+        Download files using globus transfer url with progress bar for each file.
+        When skip_if_downloaded_already is True, files are pre-filtered so that
+        only missing or incomplete files are submitted to the worker pool,
+        ensuring the -w parallel_files parameter is fully utilised.
+        When checksum_map is provided, existing files are validated against
+        their expected checksum; corrupted files are re-downloaded.
         :param file_list_json: file list in json format
         :param output_folder: folder to download the files
         :param skip_if_downloaded_already: Boolean value to skip the download if the file has already been downloaded.
+        :param parallel_files: number of files to download simultaneously
+        :param checksum_map: mapping of file name to expected MD5 checksum
         """
+        if checksum_map is None:
+            checksum_map = {}
 
         if not (os.path.isdir(output_folder)):
             os.mkdir(output_folder, exist_ok=True)
 
+        # --- Phase 0: pre-filter files that need downloading -----------------
+        files_to_download: List[Dict] = []
         for file in file_list_json:
-            try:
-                download_url = Files._get_download_url(file, "globus")
+            download_url = Files._get_download_url(file, "globus")
+            new_file_path = Files.get_output_file_name(download_url, file, output_folder)
+            if skip_if_downloaded_already and os.path.exists(new_file_path):
+                expected_cs = checksum_map.get(file.get("fileName", ""))
+                if expected_cs:
+                    valid, reason = Files.validate_download(new_file_path, expected_cs)
+                    if not valid:
+                        logging.warning(f"Corrupted file detected ({reason}), will re-download: {new_file_path}")
+                        files_to_download.append(file)
+                        continue
+                logging.info(f"Skipping download as file already exists: {new_file_path}")
+                continue
+            files_to_download.append(file)
 
-                logging.debug(f"Downloading from Globus: {download_url}")
+        if not files_to_download:
+            logging.info("All files already downloaded, nothing to do.")
+            return
 
-                # Create a clean filename to save the downloaded file
-                new_file_path = Files.get_output_file_name(download_url, file, output_folder)
+        logging.info(
+            f"{len(file_list_json) - len(files_to_download)} file(s) skipped, "
+            f"{len(files_to_download)} file(s) to download"
+        )
 
-                if skip_if_downloaded_already == True and os.path.exists(new_file_path):
-                    logging.info("Skipping download as file already exists")
-                    continue
-
-                Files._parallel_download(download_url, new_file_path)
-                logging.info(f"Successfully downloaded {new_file_path}")
-
-            except Exception as e:
-                logging.error(f"Download from Globus failed for {new_file_path}: {str(e)}")
+        # --- Phase 1: download (skip check already done, pass False) ---------
+        parallel_files = min(parallel_files, 3)
+        if parallel_files < 2:
+            for file in files_to_download:
+                try:
+                    Files._globus_download_one(
+                        file, output_folder, False
+                    )
+                    new_file_path = Files.get_output_file_name(
+                        Files._get_download_url(file, "globus"), file, output_folder
+                    )
+                    logging.info(f"Successfully downloaded {new_file_path}")
+                except Exception as e:
+                    logging.error(f"Download from Globus failed: {str(e)}")
+        else:
+            logging.info(f"Downloading {len(files_to_download)} file(s) with {parallel_files} parallel workers")
+            with ThreadPoolExecutor(max_workers=parallel_files) as executor:
+                futures = {
+                    executor.submit(
+                        Files._globus_download_one,
+                        file, output_folder, False,
+                    ): file
+                    for file in files_to_download
+                }
+                for future in as_completed(futures):
+                    try:
+                        future.result()
+                    except Exception as e:
+                        logging.error(f"Download from Globus failed: {str(e)}")
 
     @staticmethod
     def download_files_from_s3(
@@ -907,6 +954,8 @@ class Files:
         protocol: str,
         skip_if_downloaded_already: bool,
         aspera_maximum_bandwidth: str,
+        parallel_files: int = 1,
+        checksum_map: Optional[Dict[str, str]] = None,
     ) -> None:
         """
         Transfer a batch of files with one protocol, reusing a single
@@ -934,6 +983,8 @@ class Files:
                 file_list,
                 output_folder,
                 skip_if_downloaded_already=skip_if_downloaded_already,
+                parallel_files=parallel_files,
+                checksum_map=checksum_map or {},
             )
             return
         if protocol == "s3":
@@ -953,6 +1004,7 @@ class Files:
         expected_checksum: Optional[str],
         aspera_maximum_bandwidth: str,
         max_protocol_retries: int = 2,
+        parallel_files: int = 1,
     ) -> bool:
         """
         Download one file by trying each protocol in sequence, validating
@@ -975,6 +1027,7 @@ class Files:
                         protocol,
                         skip_if_downloaded_already=False,
                         aspera_maximum_bandwidth=aspera_maximum_bandwidth,
+                        parallel_files=parallel_files,
                     )
                 except Exception as error:
                     logging.error(
@@ -1009,6 +1062,7 @@ class Files:
         protocol: str = "ftp",
         aspera_maximum_bandwidth: str = "100M",  # Aspera maximum bandwidth
         checksum_check=False,
+        parallel_files: int = 1,
     ):
         """
         Download files using either FTP or Aspera transfer protocol.
@@ -1037,7 +1091,8 @@ class Files:
 
         protocol_sequence = Files._protocol_sequence(protocol)
         primary_protocol = protocol_sequence[0]
-        fallback_sequence = protocol_sequence[1:]
+        # Retry with the primary protocol first, then fall back to others
+        fallback_sequence = protocol_sequence
 
         # Phase 1: batch download with the requested protocol. Reuses a single
         # FTP/S3 connection for all files (the previous behaviour) instead of
@@ -1052,6 +1107,8 @@ class Files:
                 primary_protocol,
                 skip_if_downloaded_already=skip_if_downloaded_already,
                 aspera_maximum_bandwidth=aspera_maximum_bandwidth,
+                parallel_files=parallel_files,
+                checksum_map=checksum_map,
             )
         except Exception as exc:
             logging.warning(
@@ -1060,10 +1117,12 @@ class Files:
 
         # Phase 2: validate every file and fall back per-file for the ones
         # that are missing or invalid.
+        logging.info("Phase 2: validating %d downloaded file(s)", len(file_list_json))
         failed_files: List[str] = []
-        for file_record in file_list_json:
+        for i, file_record in enumerate(file_list_json, 1):
             expected_checksum = checksum_map.get(file_record["fileName"])
             local_path = Files._resolve_local_path(file_record, output_folder)
+            logging.info("Validating [%d/%d] %s", i, len(file_list_json), file_record["fileName"])
             valid, reason = Files.validate_download(local_path, expected_checksum)
             if valid:
                 continue
@@ -1071,7 +1130,8 @@ class Files:
             logging.warning(
                 f"{file_record['fileName']} invalid after {primary_protocol} ({reason})"
             )
-            Files._remove_if_exists(local_path)
+            if "checksum mismatch" in reason:
+                Files._remove_if_exists(local_path)
 
             if not fallback_sequence:
                 failed_files.append(file_record.get("fileName", "<unknown>"))
@@ -1083,6 +1143,7 @@ class Files:
                 protocol_sequence=fallback_sequence,
                 expected_checksum=expected_checksum,
                 aspera_maximum_bandwidth=aspera_maximum_bandwidth,
+                parallel_files=parallel_files,
             )
             if not success:
                 failed_files.append(file_record.get("fileName", "<unknown>"))
@@ -1146,6 +1207,7 @@ class Files:
         urls: List[str],
         output_folder: str,
         skip_if_downloaded_already: bool = False,
+        protocol: str = "ftp",
     ) -> None:
         """Download files from a list of raw URLs, dispatched by URL scheme.
 
@@ -1157,6 +1219,9 @@ class Files:
         :param urls: fully-qualified URLs (each contains its scheme)
         :param output_folder: directory to write downloaded files into
         :param skip_if_downloaded_already: skip URLs whose target file exists
+        :param protocol: ``ftp`` (default) for single-connection per URL scheme;
+            ``globus`` for parallel multi-Range downloads on http/https URLs
+            (no effect on ftp:// URLs which always use single-connection FTP)
         :raises ValueError: if ``urls`` is empty
         :raises RuntimeError: if one or more URLs failed
         """
@@ -1168,7 +1233,9 @@ class Files:
         failures: List[Tuple[str, str]] = []
         for url in urls:
             try:
-                Files._download_single_url(url, output_folder, skip_if_downloaded_already)
+                Files._download_single_url(
+                    url, output_folder, skip_if_downloaded_already, protocol,
+                )
             except Exception as exc:  # pylint: disable=broad-except
                 logging.error("Failed to download %s: %s", url, exc)
                 failures.append((url, str(exc)))
@@ -1184,6 +1251,7 @@ class Files:
         url: str,
         output_folder: str,
         skip_if_exists: bool = False,
+        protocol: str = "ftp",
     ) -> str:
         """Download one URL, dispatched by scheme; return the local file path."""
         parsed = urlparse(url)
@@ -1199,7 +1267,7 @@ class Files:
             logging.info("Skipping %s: already downloaded", file_name)
             return target
 
-        Files._dispatch_url_scheme(parsed, target)
+        Files._dispatch_url_scheme(parsed, target, protocol)
 
         ok, reason = Files.validate_download(target)
         if not ok:
@@ -1208,11 +1276,19 @@ class Files:
         return target
 
     @staticmethod
-    def _dispatch_url_scheme(parsed, target: str) -> None:
-        """Route a parsed URL to its protocol-specific downloader."""
+    def _dispatch_url_scheme(parsed, target: str, protocol: str = "ftp") -> None:
+        """Route a parsed URL to its protocol-specific downloader.
+
+        ``protocol='globus'`` swaps the http/https single-connection streamer
+        for :meth:`_parallel_download` (single-connection with progress bar).
+        ftp:// URLs are unaffected.
+        """
         scheme = (parsed.scheme or "").lower()
         if scheme in ("http", "https"):
-            Files._http_download_url(parsed.geturl(), target)
+            if protocol == "globus":
+                Files._parallel_download(parsed.geturl(), target)
+            else:
+                Files._http_download_url(parsed.geturl(), target)
         elif scheme == "ftp":
             Files._ftp_download_url(parsed, target)
         else:
@@ -1276,6 +1352,7 @@ class Files:
         checksum_check: bool,
         categories: List[str] = None,
         category: str = None,
+        parallel_files: int = 1,
     ):
         """
         Download all files of specified categories from a PRIDE project.
@@ -1300,6 +1377,7 @@ class Files:
             protocol,
             aspera_maximum_bandwidth=aspera_maximum_bandwidth,
             checksum_check=checksum_check,
+            parallel_files=parallel_files,
         )
 
     def get_all_category_file_list(

--- a/pridepy/files/files.py
+++ b/pridepy/files/files.py
@@ -513,8 +513,9 @@ class Files:
 
     @staticmethod
     def _parallel_download(url, file_path, position=0):
-        """Download a file using parallel Range requests, like browser parallel downloading.
-        Supports resume: if a partial file exists, continues from where it left off."""
+        """Download a file via a single-connection HTTP stream with optional resume.
+        If a partial file exists and the server supports Range requests, resumes
+        from where it left off; otherwise restarts from scratch."""
         session = Util.create_session_with_retries()
         try:
             head = session.head(url, timeout=(30, 30))
@@ -538,6 +539,9 @@ class Files:
         headers = {"Range": f"bytes={resume_size}-"} if resume_size > 0 else {}
         with session.get(url, headers=headers, stream=True, timeout=(30, 60)) as r:
             r.raise_for_status()
+            if resume_size > 0 and r.status_code != 206:
+                logging.warning("Server did not honor Range request (status %s), restarting download", r.status_code)
+                resume_size = 0
             with tqdm(total=total_size, unit="B", unit_scale=True, desc=file_path,
                       initial=resume_size, position=position, leave=True) as pbar:
                 mode = "ab" if resume_size > 0 else "wb"
@@ -589,7 +593,7 @@ class Files:
             checksum_map = {}
 
         if not (os.path.isdir(output_folder)):
-            os.mkdir(output_folder, exist_ok=True)
+            os.makedirs(output_folder, exist_ok=True)
 
         # --- Phase 0: pre-filter files that need downloading -----------------
         files_to_download: List[Dict] = []
@@ -1237,7 +1241,7 @@ class Files:
         :param output_folder: directory to write downloaded files into
         :param skip_if_downloaded_already: skip URLs whose target file exists
         :param protocol: ``ftp`` (default) for single-connection per URL scheme;
-            ``globus`` for parallel multi-Range downloads on http/https URLs
+            ``globus`` for resume-capable http/https downloads (single-connection stream)
             (no effect on ftp:// URLs which always use single-connection FTP)
         :param checksum_check: validate downloads against PRIDE checksum API;
             accessions are inferred from URL paths (only PRIDE URLs supported)

--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -46,9 +46,16 @@ def main():
 @click.option(
     "--checksum-check",
     required=False,
-    help="Download checksum file for project",
+    help="Download checksum file for project and validate downloads",
     is_flag=True,
     default=False,
+)
+@click.option(
+    "-w",
+    "--parallel-files",
+    default=1,
+    type=int,
+    help="Number of files to download simultaneously for globus (max 3). Default is 1.",
 )
 def download_all_public_raw_files(
     accession,
@@ -57,6 +64,7 @@ def download_all_public_raw_files(
     skip_if_downloaded_already,
     aspera_maximum_bandwidth: str = "50M",
     checksum_check: bool = False,
+    parallel_files: int = 1,
 ):
     """
     Command to download all public raw files from a specified PRIDE project.
@@ -68,6 +76,7 @@ def download_all_public_raw_files(
         skip_if_downloaded_already (bool): Skip download if files already exist. Default is False.
         aspera_maximum_bandwidth (str): Maximum bandwidth for Aspera protocol. Default is 100M.
         checksum_check (bool): Flag to download checksum file for the project. Default is False.
+        parallel_files (int): Number of files to download simultaneously. Default is 1.
     """
 
     raw_files = Files()
@@ -84,6 +93,7 @@ def download_all_public_raw_files(
         protocol,
         aspera_maximum_bandwidth=aspera_maximum_bandwidth,
         checksum_check=checksum_check,
+        parallel_files=parallel_files,
     )
 
 
@@ -120,7 +130,7 @@ def download_all_public_raw_files(
 @click.option(
     "--checksum-check",
     required=False,
-    help="Download checksum file for project",
+    help="Download checksum file for project and validate downloads",
     is_flag=True,
     default=False,
 )
@@ -131,6 +141,13 @@ def download_all_public_raw_files(
     help="Comma-separated categories of files to download (e.g. RAW or RAW,SEARCH). "
     "Valid values: RAW, PEAK, SEARCH, RESULT, SPECTRUM_LIBRARY, OTHER, FASTA",
 )
+@click.option(
+    "-w",
+    "--parallel-files",
+    default=1,
+    type=int,
+    help="Number of files to download simultaneously for globus (max 3). Default is 1.",
+)
 def download_all_public_category_files(
     accession: str,
     protocol: str,
@@ -139,6 +156,7 @@ def download_all_public_category_files(
     aspera_maximum_bandwidth: str = "50M",
     checksum_check: bool = False,
     category: str = "RAW",
+    parallel_files: int = 1,
 ):
     """
     Command to download all public files of a specified category from a given PRIDE public project.
@@ -151,6 +169,7 @@ def download_all_public_category_files(
         aspera_maximum_bandwidth (str): Maximum bandwidth for Aspera transfers.
         checksum_check (bool): If True, downloads the checksum file for the project.
         category (str): Comma-separated categories of files to download (e.g. RAW or RAW,SEARCH).
+        parallel_files (int): Number of files to download simultaneously. Default is 1.
     """
 
     valid_categories = {"RAW", "PEAK", "SEARCH", "RESULT", "SPECTRUM_LIBRARY", "OTHER", "FASTA"}
@@ -177,6 +196,7 @@ def download_all_public_category_files(
         aspera_maximum_bandwidth=aspera_maximum_bandwidth,
         checksum_check=checksum_check,
         categories=categories,
+        parallel_files=parallel_files,
     )
 
 
@@ -216,7 +236,7 @@ def download_all_public_category_files(
 @click.option(
     "--checksum-check",
     required=False,
-    help="Download checksum file for project",
+    help="Download checksum file for project and validate downloads",
     is_flag=True,
     default=False,
 )
@@ -598,20 +618,30 @@ def download_files_by_list(
     default=False,
     help="Skip URLs whose target file already exists locally.",
 )
+@click.option(
+    "-p",
+    "--protocol",
+    default="ftp",
+    type=click.Choice(["ftp", "globus"], case_sensitive=False),
+    help="Download strategy. ftp (default): single-connection per URL scheme. "
+         "globus: parallel multi-Range downloads on http/https URLs.",
+)
 def download_files_by_url(
     url_list_path,
     urls_csv,
     single_url,
     output_folder,
     skip_if_downloaded_already,
+    protocol,
 ):
     """Download files from raw URLs (http/https/ftp), dispatched by scheme."""
     urls = _read_url_arguments(url_list_path, single_url, urls_csv)
-    logging.info("Downloading %d URL(s)", len(urls))
+    logging.info("Downloading %d URL(s) [protocol=%s]", len(urls), protocol)
     Files.download_files_by_url(
         urls=urls,
         output_folder=output_folder,
         skip_if_downloaded_already=skip_if_downloaded_already,
+        protocol=protocol,
     )
 
 

--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -464,15 +464,19 @@ def _read_filename_arguments(file_list_path, files_csv):
     return deduped
 
 
-def _read_url_arguments(url_list_path, single_url):
-    """Build a deduplicated URL list from a manifest path and/or single URL.
+def _read_url_arguments(url_list_path, single_url, urls_csv=None):
+    """Build a deduplicated URL list from a manifest path, a CSV string,
+    and/or a single URL.
 
     Manifest format: one URL per line; blank lines and ``#``-prefixed comments
-    are skipped.
+    are skipped. URLs are RFC 3986 compliant and never contain bare commas, so
+    splitting ``urls_csv`` on ``,`` is safe.
     """
-    if not url_list_path and not single_url:
-        raise click.BadParameter("Provide either --url-list or --url")
+    if not url_list_path and not single_url and not urls_csv:
+        raise click.BadParameter("Provide --url-list, --urls, or --url")
     urls = list(_parse_text_manifest(url_list_path))
+    if urls_csv:
+        urls.extend(part.strip() for part in urls_csv.split(",") if part.strip())
     if single_url:
         urls.append(single_url)
     deduped = list(dict.fromkeys(urls))
@@ -571,6 +575,12 @@ def download_files_by_list(
     help="Path to a manifest file with one URL per line.",
 )
 @click.option(
+    "--urls",
+    "urls_csv",
+    required=False,
+    help="Comma-separated URLs. Use this OR --url-list / --url (or combine).",
+)
+@click.option(
     "--url",
     "single_url",
     required=False,
@@ -590,12 +600,13 @@ def download_files_by_list(
 )
 def download_files_by_url(
     url_list_path,
+    urls_csv,
     single_url,
     output_folder,
     skip_if_downloaded_already,
 ):
     """Download files from raw URLs (http/https/ftp), dispatched by scheme."""
-    urls = _read_url_arguments(url_list_path, single_url)
+    urls = _read_url_arguments(url_list_path, single_url, urls_csv)
     logging.info("Downloading %d URL(s)", len(urls))
     Files.download_files_by_url(
         urls=urls,

--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -484,21 +484,18 @@ def _read_filename_arguments(file_list_path, files_csv):
     return deduped
 
 
-def _read_url_arguments(url_list_path, single_url, urls_csv=None):
-    """Build a deduplicated URL list from a manifest path, a CSV string,
-    and/or a single URL.
+def _read_url_arguments(url_list_path, urls_csv=None):
+    """Build a deduplicated URL list from a manifest path and/or a CSV string.
 
     Manifest format: one URL per line; blank lines and ``#``-prefixed comments
     are skipped. URLs are RFC 3986 compliant and never contain bare commas, so
     splitting ``urls_csv`` on ``,`` is safe.
     """
-    if not url_list_path and not single_url and not urls_csv:
-        raise click.BadParameter("Provide --url-list, --urls, or --url")
+    if not url_list_path and not urls_csv:
+        raise click.BadParameter("Provide --url-list or --urls")
     urls = list(_parse_text_manifest(url_list_path))
     if urls_csv:
         urls.extend(part.strip() for part in urls_csv.split(",") if part.strip())
-    if single_url:
-        urls.append(single_url)
     deduped = list(dict.fromkeys(urls))
     if not deduped:
         raise click.BadParameter("No URLs found in the provided inputs")
@@ -556,6 +553,13 @@ def _read_url_arguments(url_list_path, single_url, urls_csv=None):
     default=False,
     help="Download project checksums and validate downloaded files.",
 )
+@click.option(
+    "-w",
+    "--parallel-files",
+    default=1,
+    type=int,
+    help="Number of files to download simultaneously for globus (max 3). Default is 1.",
+)
 def download_files_by_list(
     accession,
     protocol,
@@ -565,6 +569,7 @@ def download_files_by_list(
     skip_if_downloaded_already,
     aspera_maximum_bandwidth,
     checksum_check,
+    parallel_files,
 ):
     """Download a named subset of files from a PRIDE project."""
     file_names = _read_filename_arguments(file_list_path, files_csv)
@@ -579,6 +584,7 @@ def download_files_by_list(
         protocol=protocol,
         aspera_maximum_bandwidth=aspera_maximum_bandwidth,
         checksum_check=checksum_check,
+        parallel_files=parallel_files,
     )
 
 
@@ -595,16 +601,11 @@ def download_files_by_list(
     help="Path to a manifest file with one URL per line.",
 )
 @click.option(
+    "-u",
     "--urls",
     "urls_csv",
     required=False,
-    help="Comma-separated URLs. Use this OR --url-list / --url (or combine).",
-)
-@click.option(
-    "--url",
-    "single_url",
-    required=False,
-    help="Single URL. Use this OR --url-list (or both).",
+    help="One or more comma-separated URLs. Use this OR --url-list (or both).",
 )
 @click.option(
     "-o",
@@ -626,22 +627,39 @@ def download_files_by_list(
     help="Download strategy. ftp (default): single-connection per URL scheme. "
          "globus: parallel multi-Range downloads on http/https URLs.",
 )
+@click.option(
+    "--checksum-check",
+    is_flag=True,
+    default=False,
+    help="Validate downloaded files against PRIDE checksums. "
+         "Accessions are inferred from PRIDE URL paths (only PRIDE URLs supported).",
+)
+@click.option(
+    "-w",
+    "--parallel-files",
+    default=1,
+    type=int,
+    help="Number of files to download simultaneously for globus (max 3). Default is 1.",
+)
 def download_files_by_url(
     url_list_path,
     urls_csv,
-    single_url,
     output_folder,
     skip_if_downloaded_already,
     protocol,
+    checksum_check,
+    parallel_files,
 ):
     """Download files from raw URLs (http/https/ftp), dispatched by scheme."""
-    urls = _read_url_arguments(url_list_path, single_url, urls_csv)
+    urls = _read_url_arguments(url_list_path, urls_csv)
     logging.info("Downloading %d URL(s) [protocol=%s]", len(urls), protocol)
     Files.download_files_by_url(
         urls=urls,
         output_folder=output_folder,
         skip_if_downloaded_already=skip_if_downloaded_already,
         protocol=protocol,
+        parallel_files=parallel_files,
+        checksum_check=checksum_check,
     )
 
 

--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -54,8 +54,8 @@ def main():
     "-w",
     "--parallel-files",
     default=1,
-    type=int,
-    help="Number of files to download simultaneously for globus (max 3). Default is 1.",
+    type=click.IntRange(1, 3),
+    help="Number of files to download simultaneously for globus (1-3). Default is 1.",
 )
 def download_all_public_raw_files(
     accession,
@@ -145,8 +145,8 @@ def download_all_public_raw_files(
     "-w",
     "--parallel-files",
     default=1,
-    type=int,
-    help="Number of files to download simultaneously for globus (max 3). Default is 1.",
+    type=click.IntRange(1, 3),
+    help="Number of files to download simultaneously for globus (1-3). Default is 1.",
 )
 def download_all_public_category_files(
     accession: str,
@@ -488,8 +488,8 @@ def _read_url_arguments(url_list_path, urls_csv=None):
     """Build a deduplicated URL list from a manifest path and/or a CSV string.
 
     Manifest format: one URL per line; blank lines and ``#``-prefixed comments
-    are skipped. URLs are RFC 3986 compliant and never contain bare commas, so
-    splitting ``urls_csv`` on ``,`` is safe.
+    are skipped. ``urls_csv`` is split on ``,``; URLs containing literal
+    commas should be provided via a manifest file instead.
     """
     if not url_list_path and not urls_csv:
         raise click.BadParameter("Provide --url-list or --urls")
@@ -557,8 +557,8 @@ def _read_url_arguments(url_list_path, urls_csv=None):
     "-w",
     "--parallel-files",
     default=1,
-    type=int,
-    help="Number of files to download simultaneously for globus (max 3). Default is 1.",
+    type=click.IntRange(1, 3),
+    help="Number of files to download simultaneously for globus (1-3). Default is 1.",
 )
 def download_files_by_list(
     accession,
@@ -625,7 +625,7 @@ def download_files_by_list(
     default="ftp",
     type=click.Choice(["ftp", "globus"], case_sensitive=False),
     help="Download strategy. ftp (default): single-connection per URL scheme. "
-         "globus: parallel multi-Range downloads on http/https URLs.",
+         "globus: resume-capable http/https downloads (single-connection stream).",
 )
 @click.option(
     "--checksum-check",
@@ -638,8 +638,8 @@ def download_files_by_list(
     "-w",
     "--parallel-files",
     default=1,
-    type=int,
-    help="Number of files to download simultaneously for globus (max 3). Default is 1.",
+    type=click.IntRange(1, 3),
+    help="Number of files to download simultaneously for globus (1-3). Default is 1.",
 )
 def download_files_by_url(
     url_list_path,

--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -427,5 +427,182 @@ def search_projects_by_keywords_and_filters(
     )
 
 
+def _parse_text_manifest(path, *, take_first_column=False):
+    """Read a text manifest, skipping blank lines and ``#``-prefixed comments.
+
+    When ``take_first_column`` is True, each line is split on tabs and only
+    the first cell is kept (used by the filename-list manifest).
+    """
+    if not path:
+        return []
+    items = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for raw in handle:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if take_first_column:
+                line = line.split("\t")[0].strip()
+            items.append(line)
+    return items
+
+
+def _read_filename_arguments(file_list_path, files_csv):
+    """Build a deduplicated filename list from a manifest path and/or CSV string.
+
+    The manifest takes one filename per line (additional tab-separated columns
+    are ignored); blank lines and ``#``-prefixed comments are skipped.
+    """
+    if not file_list_path and not files_csv:
+        raise click.BadParameter("Provide either --file-list or --files")
+    names = list(_parse_text_manifest(file_list_path, take_first_column=True))
+    if files_csv:
+        names.extend(part.strip() for part in files_csv.split(",") if part.strip())
+    deduped = list(dict.fromkeys(names))
+    if not deduped:
+        raise click.BadParameter("No filenames found in the provided inputs")
+    return deduped
+
+
+def _read_url_arguments(url_list_path, single_url):
+    """Build a deduplicated URL list from a manifest path and/or single URL.
+
+    Manifest format: one URL per line; blank lines and ``#``-prefixed comments
+    are skipped.
+    """
+    if not url_list_path and not single_url:
+        raise click.BadParameter("Provide either --url-list or --url")
+    urls = list(_parse_text_manifest(url_list_path))
+    if single_url:
+        urls.append(single_url)
+    deduped = list(dict.fromkeys(urls))
+    if not deduped:
+        raise click.BadParameter("No URLs found in the provided inputs")
+    return deduped
+
+
+@main.command(
+    "download-files-by-list",
+    help="Download a subset of files from a PRIDE project, given a filename list",
+)
+@click.option("-a", "--accession", required=True, help="PRIDE project accession")
+@click.option(
+    "-p",
+    "--protocol",
+    default="ftp",
+    type=PROTOCOL_CHOICES,
+    help="Protocol to use for download: ftp, aspera, globus, s3. Default is ftp with fallback enabled.",
+)
+@click.option(
+    "-F",
+    "--file-list",
+    "file_list_path",
+    required=False,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to a manifest file with one filename per line.",
+)
+@click.option(
+    "-f",
+    "--files",
+    "files_csv",
+    required=False,
+    help="Comma-separated filenames. Use this OR --file-list (or both).",
+)
+@click.option(
+    "-o",
+    "--output-folder",
+    required=True,
+    help="output folder to download files",
+)
+@click.option(
+    "--skip-if-downloaded-already",
+    is_flag=True,
+    default=False,
+    help="Skip the download if the file has already been downloaded.",
+)
+@click.option(
+    "--aspera-maximum-bandwidth",
+    required=False,
+    default="100M",
+    help="Aspera maximum bandwidth (e.g 50M, 100M, 200M).",
+)
+@click.option(
+    "--checksum-check",
+    is_flag=True,
+    default=False,
+    help="Download project checksums and validate downloaded files.",
+)
+def download_files_by_list(
+    accession,
+    protocol,
+    file_list_path,
+    files_csv,
+    output_folder,
+    skip_if_downloaded_already,
+    aspera_maximum_bandwidth,
+    checksum_check,
+):
+    """Download a named subset of files from a PRIDE project."""
+    file_names = _read_filename_arguments(file_list_path, files_csv)
+    files_obj = Files()
+    logging.info("accession: %s", accession)
+    logging.info("Downloading %d file(s) via %s", len(file_names), protocol)
+    files_obj.download_files_by_list(
+        accession=accession,
+        file_names=file_names,
+        output_folder=output_folder,
+        skip_if_downloaded_already=skip_if_downloaded_already,
+        protocol=protocol,
+        aspera_maximum_bandwidth=aspera_maximum_bandwidth,
+        checksum_check=checksum_check,
+    )
+
+
+@main.command(
+    "download-files-by-url",
+    help="Download files from a list of raw URLs (http/https/ftp)",
+)
+@click.option(
+    "-F",
+    "--url-list",
+    "url_list_path",
+    required=False,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to a manifest file with one URL per line.",
+)
+@click.option(
+    "--url",
+    "single_url",
+    required=False,
+    help="Single URL. Use this OR --url-list (or both).",
+)
+@click.option(
+    "-o",
+    "--output-folder",
+    required=True,
+    help="output folder to download files into",
+)
+@click.option(
+    "--skip-if-downloaded-already",
+    is_flag=True,
+    default=False,
+    help="Skip URLs whose target file already exists locally.",
+)
+def download_files_by_url(
+    url_list_path,
+    single_url,
+    output_folder,
+    skip_if_downloaded_already,
+):
+    """Download files from raw URLs (http/https/ftp), dispatched by scheme."""
+    urls = _read_url_arguments(url_list_path, single_url)
+    logging.info("Downloading %d URL(s)", len(urls))
+    Files.download_files_by_url(
+        urls=urls,
+        output_folder=output_folder,
+        skip_if_downloaded_already=skip_if_downloaded_already,
+    )
+
+
 if __name__ == "__main__":
     main()

--- a/pridepy/tests/test_download_by_list.py
+++ b/pridepy/tests/test_download_by_list.py
@@ -1,0 +1,125 @@
+"""Unit tests for ``download-files-by-list`` (Case 1).
+
+Covers the :class:`Files` method and the CLI manifest-parsing helper.
+Network is fully mocked.
+"""
+
+import os
+import tempfile
+from unittest import TestCase
+from unittest.mock import patch
+
+import click
+import pytest
+
+from pridepy.files.files import Files
+from pridepy.pridepy import _read_filename_arguments
+
+
+class TestDownloadFilesByList(TestCase):
+    """End-to-end behaviour of ``Files.download_files_by_list``."""
+
+    def test_raises_on_empty_list(self):
+        with pytest.raises(ValueError, match="must contain at least one"):
+            Files().download_files_by_list(
+                accession="PXD001819",
+                file_names=[],
+                output_folder="/tmp",
+                skip_if_downloaded_already=False,
+            )
+
+    def test_filters_metadata_and_delegates(self):
+        files_obj = Files()
+        api_response = [
+            {"fileName": "a.raw"},
+            {"fileName": "b.raw"},
+            {"fileName": "c.raw"},
+        ]
+        with patch.object(
+            files_obj, "stream_all_files_by_project", return_value=api_response
+        ), patch.object(files_obj, "download_files") as mock_download:
+            files_obj.download_files_by_list(
+                accession="PXD001819",
+                file_names=["a.raw", "c.raw"],
+                output_folder="/tmp",
+                skip_if_downloaded_already=False,
+                protocol="ftp",
+            )
+
+        args, _ = mock_download.call_args
+        matched = args[0]
+        assert {f["fileName"] for f in matched} == {"a.raw", "c.raw"}
+
+    def test_warns_on_partial_match(self):
+        files_obj = Files()
+        api_response = [{"fileName": "a.raw"}]
+        with patch.object(
+            files_obj, "stream_all_files_by_project", return_value=api_response
+        ), patch.object(files_obj, "download_files") as mock_download, self.assertLogs(
+            level="WARNING"
+        ) as log_ctx:
+            files_obj.download_files_by_list(
+                accession="PXD001819",
+                file_names=["a.raw", "missing.raw"],
+                output_folder="/tmp",
+                skip_if_downloaded_already=False,
+            )
+
+        assert any("missing.raw" in record.getMessage() for record in log_ctx.records)
+        mock_download.assert_called_once()
+
+    def test_raises_when_no_files_match(self):
+        files_obj = Files()
+        with patch.object(
+            files_obj, "stream_all_files_by_project", return_value=[]
+        ):
+            with pytest.raises(ValueError, match="No matching files"):
+                files_obj.download_files_by_list(
+                    accession="PXD001819",
+                    file_names=["a.raw"],
+                    output_folder="/tmp",
+                    skip_if_downloaded_already=False,
+                )
+
+
+class TestReadFilenameArguments(TestCase):
+    """CLI helper that builds the deduplicated filename list."""
+
+    def test_no_input_raises(self):
+        with pytest.raises(click.BadParameter):
+            _read_filename_arguments(None, None)
+
+    def test_csv_only(self):
+        assert _read_filename_arguments(None, "a.raw,b.raw,c.raw") == [
+            "a.raw",
+            "b.raw",
+            "c.raw",
+        ]
+
+    def test_manifest_skips_blank_and_comments(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest = os.path.join(tmp_dir, "files.txt")
+            with open(manifest, "w", encoding="utf-8") as handle:
+                handle.write("a.raw\n\n# comment line\nb.raw\nc.raw\tftp\n")
+            assert _read_filename_arguments(manifest, None) == [
+                "a.raw",
+                "b.raw",
+                "c.raw",
+            ]
+
+    def test_dedupe(self):
+        assert _read_filename_arguments(None, "a.raw,b.raw,a.raw") == [
+            "a.raw",
+            "b.raw",
+        ]
+
+    def test_manifest_plus_csv_dedup(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest = os.path.join(tmp_dir, "files.txt")
+            with open(manifest, "w", encoding="utf-8") as handle:
+                handle.write("a.raw\nb.raw\n")
+            assert _read_filename_arguments(manifest, "b.raw,c.raw") == [
+                "a.raw",
+                "b.raw",
+                "c.raw",
+            ]

--- a/pridepy/tests/test_download_by_url.py
+++ b/pridepy/tests/test_download_by_url.py
@@ -110,12 +110,18 @@ class TestReadUrlArguments(TestCase):
 
     def test_no_input_raises(self):
         with pytest.raises(click.BadParameter):
-            _read_url_arguments(None, None)
+            _read_url_arguments(None)
 
     def test_single_url(self):
         assert _read_url_arguments(None, "https://example.org/a.raw") == [
             "https://example.org/a.raw"
         ]
+
+    def test_multiple_urls_csv(self):
+        assert _read_url_arguments(
+            None,
+            "https://a.com/x.raw,ftp://b.com/y.raw,https://a.com/x.raw",
+        ) == ["https://a.com/x.raw", "ftp://b.com/y.raw"]
 
     def test_manifest(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -132,33 +138,15 @@ class TestReadUrlArguments(TestCase):
                 "ftp://b.com/y.raw",
             ]
 
-    def test_manifest_plus_single_dedupe(self):
+    def test_manifest_plus_csv_dedupe(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             manifest = os.path.join(tmp_dir, "urls.txt")
             with open(manifest, "w", encoding="utf-8") as handle:
                 handle.write("https://a.com/x.raw\nhttps://a.com/y.raw\n")
             assert _read_url_arguments(
-                manifest, "https://a.com/y.raw"
-            ) == ["https://a.com/x.raw", "https://a.com/y.raw"]
-
-    def test_csv_only(self):
-        assert _read_url_arguments(
-            None,
-            None,
-            "https://a.com/x.raw,ftp://b.com/y.raw,https://a.com/x.raw",
-        ) == ["https://a.com/x.raw", "ftp://b.com/y.raw"]
-
-    def test_manifest_csv_single_combined_dedupe(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            manifest = os.path.join(tmp_dir, "urls.txt")
-            with open(manifest, "w", encoding="utf-8") as handle:
-                handle.write("https://a.com/x.raw\n")
-            assert _read_url_arguments(
-                manifest,
-                "https://a.com/z.raw",
-                "ftp://b.com/y.raw,https://a.com/x.raw",
+                manifest, "https://a.com/y.raw,ftp://b.com/z.raw"
             ) == [
                 "https://a.com/x.raw",
-                "ftp://b.com/y.raw",
-                "https://a.com/z.raw",
+                "https://a.com/y.raw",
+                "ftp://b.com/z.raw",
             ]

--- a/pridepy/tests/test_download_by_url.py
+++ b/pridepy/tests/test_download_by_url.py
@@ -140,3 +140,25 @@ class TestReadUrlArguments(TestCase):
             assert _read_url_arguments(
                 manifest, "https://a.com/y.raw"
             ) == ["https://a.com/x.raw", "https://a.com/y.raw"]
+
+    def test_csv_only(self):
+        assert _read_url_arguments(
+            None,
+            None,
+            "https://a.com/x.raw,ftp://b.com/y.raw,https://a.com/x.raw",
+        ) == ["https://a.com/x.raw", "ftp://b.com/y.raw"]
+
+    def test_manifest_csv_single_combined_dedupe(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest = os.path.join(tmp_dir, "urls.txt")
+            with open(manifest, "w", encoding="utf-8") as handle:
+                handle.write("https://a.com/x.raw\n")
+            assert _read_url_arguments(
+                manifest,
+                "https://a.com/z.raw",
+                "ftp://b.com/y.raw,https://a.com/x.raw",
+            ) == [
+                "https://a.com/x.raw",
+                "ftp://b.com/y.raw",
+                "https://a.com/z.raw",
+            ]

--- a/pridepy/tests/test_download_by_url.py
+++ b/pridepy/tests/test_download_by_url.py
@@ -1,0 +1,142 @@
+"""Unit tests for ``download-files-by-url`` (Case 4).
+
+Covers :meth:`Files.download_files_by_url`, the per-URL dispatcher, and the CLI
+manifest-parsing helper. All network access is mocked.
+"""
+
+import os
+import tempfile
+from unittest import TestCase
+from unittest.mock import patch
+
+import click
+import pytest
+
+from pridepy.files.files import Files
+from pridepy.pridepy import _read_url_arguments
+
+
+def _touch_valid(path):
+    """Create a non-empty file at *path* (used as a faux successful download)."""
+    with open(path, "wb") as handle:
+        handle.write(b"data")
+
+
+class TestDownloadFilesByUrl(TestCase):
+    """Behaviour of ``Files.download_files_by_url``."""
+
+    def test_raises_on_empty_list(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.raises(ValueError, match="must contain at least one"):
+                Files.download_files_by_url(urls=[], output_folder=tmp_dir)
+
+    def test_dispatches_http(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            target = os.path.join(tmp_dir, "sample.raw")
+
+            def fake_http(_url, target_path):
+                _touch_valid(target_path)
+
+            with patch.object(
+                Files, "_http_download_url", side_effect=fake_http
+            ) as mock_http:
+                Files.download_files_by_url(
+                    urls=["https://example.org/sample.raw"],
+                    output_folder=tmp_dir,
+                )
+
+            mock_http.assert_called_once()
+            assert os.path.exists(target)
+
+    def test_dispatches_ftp(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            target = os.path.join(tmp_dir, "sample.raw")
+
+            def fake_ftp(_parsed, target_path):
+                _touch_valid(target_path)
+
+            with patch.object(
+                Files, "_ftp_download_url", side_effect=fake_ftp
+            ) as mock_ftp:
+                Files.download_files_by_url(
+                    urls=["ftp://ftp.pride.ebi.ac.uk/path/sample.raw"],
+                    output_folder=tmp_dir,
+                )
+
+            mock_ftp.assert_called_once()
+            assert os.path.exists(target)
+
+    def test_unsupported_scheme_aggregates_failure(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.raises(RuntimeError, match=r"Failed to download 1 URL"):
+                Files.download_files_by_url(
+                    urls=["s3://bucket/key/sample.raw"],
+                    output_folder=tmp_dir,
+                )
+
+    def test_aggregates_multiple_failures(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.raises(RuntimeError, match=r"Failed to download 2 URL"):
+                Files.download_files_by_url(
+                    urls=["s3://b/k/x.raw", "wat://y/z.raw"],
+                    output_folder=tmp_dir,
+                )
+
+    def test_skip_if_exists_short_circuits(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            target = os.path.join(tmp_dir, "existing.raw")
+            _touch_valid(target)
+            with patch.object(Files, "_http_download_url") as mock_http:
+                Files.download_files_by_url(
+                    urls=["https://example.org/existing.raw"],
+                    output_folder=tmp_dir,
+                    skip_if_downloaded_already=True,
+                )
+
+            mock_http.assert_not_called()
+            assert os.path.isfile(target)
+
+    def test_no_scheme_raises_aggregated(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.raises(RuntimeError, match=r"Failed to download 1 URL"):
+                Files.download_files_by_url(
+                    urls=["bare-string-without-scheme"],
+                    output_folder=tmp_dir,
+                )
+
+
+class TestReadUrlArguments(TestCase):
+    """CLI helper that builds the deduplicated URL list."""
+
+    def test_no_input_raises(self):
+        with pytest.raises(click.BadParameter):
+            _read_url_arguments(None, None)
+
+    def test_single_url(self):
+        assert _read_url_arguments(None, "https://example.org/a.raw") == [
+            "https://example.org/a.raw"
+        ]
+
+    def test_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest = os.path.join(tmp_dir, "urls.txt")
+            with open(manifest, "w", encoding="utf-8") as handle:
+                handle.write(
+                    "https://a.com/x.raw\n"
+                    "# comment\n"
+                    "\n"
+                    "ftp://b.com/y.raw\n"
+                )
+            assert _read_url_arguments(manifest, None) == [
+                "https://a.com/x.raw",
+                "ftp://b.com/y.raw",
+            ]
+
+    def test_manifest_plus_single_dedupe(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest = os.path.join(tmp_dir, "urls.txt")
+            with open(manifest, "w", encoding="utf-8") as handle:
+                handle.write("https://a.com/x.raw\nhttps://a.com/y.raw\n")
+            assert _read_url_arguments(
+                manifest, "https://a.com/y.raw"
+            ) == ["https://a.com/x.raw", "https://a.com/y.raw"]

--- a/pridepy/tests/test_download_resilience.py
+++ b/pridepy/tests/test_download_resilience.py
@@ -44,28 +44,21 @@ class TestDownloadResilience(TestCase):
 
         assert download_url == "https://ftp.pride.ebi.ac.uk/path/file.raw"
 
-    def test_parallel_download_falls_back_when_range_not_honored(self):
+    def test_parallel_download_streams_full_file(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             output_file = os.path.join(tmp_dir, "file.raw")
             session = Mock()
             head = Mock()
-            head.headers = {"content-length": "1", "accept-ranges": "bytes"}
+            head.headers = {"content-length": "3", "accept-ranges": "bytes"}
             head.raise_for_status.return_value = None
             session.head.return_value = head
 
-            ranged_response = Mock()
-            ranged_response.status_code = 200
-            ranged_response.headers = {}
-            ranged_response.raise_for_status.return_value = None
-            ranged_response.__enter__ = Mock(return_value=ranged_response)
-            ranged_response.__exit__ = Mock(return_value=None)
-
-            fallback_response = Mock()
-            fallback_response.raise_for_status.return_value = None
-            fallback_response.iter_content.return_value = [b"abc"]
-            fallback_response.__enter__ = Mock(return_value=fallback_response)
-            fallback_response.__exit__ = Mock(return_value=None)
-            session.get.side_effect = [ranged_response, fallback_response]
+            stream_response = Mock()
+            stream_response.raise_for_status.return_value = None
+            stream_response.iter_content.return_value = [b"abc"]
+            stream_response.__enter__ = Mock(return_value=stream_response)
+            stream_response.__exit__ = Mock(return_value=None)
+            session.get.return_value = stream_response
 
             with patch(
                 "pridepy.files.files.Util.create_session_with_retries",
@@ -166,7 +159,7 @@ class TestDownloadResilience(TestCase):
             attempted_protocols = []
 
             def fake_batch(file_list, output_folder, protocol, skip_if_downloaded_already,
-                           aspera_maximum_bandwidth):
+                           aspera_maximum_bandwidth, **kwargs):
                 attempted_protocols.append(protocol)
                 if protocol == "aspera":
                     with open(local_path, "wb") as handle:
@@ -204,7 +197,7 @@ class TestDownloadResilience(TestCase):
             local_path = os.path.join(tmp_dir, "happy.raw")
 
             def fake_batch(file_list, output_folder, protocol, skip_if_downloaded_already,
-                           aspera_maximum_bandwidth):
+                           aspera_maximum_bandwidth, **kwargs):
                 with open(local_path, "wb") as handle:
                     handle.write(b"data")
 

--- a/pridepy/tests/test_download_resilience.py
+++ b/pridepy/tests/test_download_resilience.py
@@ -74,7 +74,6 @@ class TestDownloadResilience(TestCase):
                 Files._parallel_download(
                     "https://example.org/file.raw",
                     output_file,
-                    num_connections=2,
                 )
 
             with open(output_file, "rb") as handle:
@@ -100,7 +99,6 @@ class TestDownloadResilience(TestCase):
                 Files._parallel_download(
                     "https://example.org/file.raw",
                     output_file,
-                    num_connections=2,
                 )
 
             with open(output_file, "rb") as handle:
@@ -129,7 +127,6 @@ class TestDownloadResilience(TestCase):
                 Files._parallel_download(
                     "https://example.org/file.raw",
                     output_file,
-                    num_connections=2,
                 )
 
             with open(output_file, "rb") as handle:


### PR DESCRIPTION
This pull request adds two new CLI commands to support downloading arbitrary subsets of files from PRIDE projects, either by filename or by raw URL, along with robust manifest parsing and parallel download support. It also introduces comprehensive unit tests for these new features and enhances documentation accordingly. The most important changes are grouped below.

**New CLI Features:**

- Added `download-files-by-list` command, allowing users to download a specified subset of files from a PRIDE project by providing a manifest file or a comma-separated list of filenames. Includes support for parallel downloads and checksum validation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R109-R150) [[2]](diffhunk://#diff-6d2444b3de21b83ffd6288dc76ad39021d24feff9847a1f26cd3dc181da9b3b4R450-R665)
- Added `download-files-by-url` command to download files directly from a list of raw URLs (http/https/ftp), with manifest and CSV support, protocol dispatch, parallel downloads, and optional checksum validation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R109-R150) [[2]](diffhunk://#diff-6d2444b3de21b83ffd6288dc76ad39021d24feff9847a1f26cd3dc181da9b3b4R450-R665)

**Manifest and Argument Parsing Helpers:**

- Implemented `_parse_text_manifest`, `_read_filename_arguments`, and `_read_url_arguments` helper functions for robust parsing and deduplication of manifest files and CSV arguments for filenames and URLs.

**Parallel Download and Option Enhancements:**

- Added `--parallel-files` (`-w`) option to relevant commands, allowing up to 3 parallel downloads when using the globus protocol. Also clarified and improved `--checksum-check` help text for all download commands. [[1]](diffhunk://#diff-6d2444b3de21b83ffd6288dc76ad39021d24feff9847a1f26cd3dc181da9b3b4L49-R67) [[2]](diffhunk://#diff-6d2444b3de21b83ffd6288dc76ad39021d24feff9847a1f26cd3dc181da9b3b4R79) [[3]](diffhunk://#diff-6d2444b3de21b83ffd6288dc76ad39021d24feff9847a1f26cd3dc181da9b3b4R96) [[4]](diffhunk://#diff-6d2444b3de21b83ffd6288dc76ad39021d24feff9847a1f26cd3dc181da9b3b4L123-R133) [[5]](diffhunk://#diff-6d2444b3de21b83ffd6288dc76ad39021d24feff9847a1f26cd3dc181da9b3b4R144-R150) [[6]](diffhunk://#diff-6d2444b3de21b83ffd6288dc76ad39021d24feff9847a1f26cd3dc181da9b3b4R159) [[7]](diffhunk://#diff-6d2444b3de21b83ffd6288dc76ad39021d24feff9847a1f26cd3dc181da9b3b4R172) [[8]](diffhunk://#diff-6d2444b3de21b83ffd6288dc76ad39021d24feff9847a1f26cd3dc181da9b3b4R199) [[9]](diffhunk://#diff-6d2444b3de21b83ffd6288dc76ad39021d24feff9847a1f26cd3dc181da9b3b4L219-R239)

**Documentation Updates:**

- Updated `README.md` with detailed usage instructions and examples for the new commands, including manifest file formats, options, and command summaries. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R109-R150) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161-R162)

**Testing:**

- Added unit tests for both `download-files-by-list` and `download-files-by-url` commands, covering manifest parsing, argument deduplication, correct dispatching, error handling, and edge cases. [[1]](diffhunk://#diff-7409374564fc9e1d7bb49083a40504d2c5ff269801cc914c979373b24e44f018R1-R125) [[2]](diffhunk://#diff-28e817c805ee26e2291815739418f43a76bbacf2e921f44bd8ef2bdf36fec568R1-R152)