### PR TITLE
Limit parallel workers to match file count and release version 0.0.15

### DIFF
--- a/pridepy/files/files.py
+++ b/pridepy/files/files.py
@@ -1253,7 +1253,7 @@ class Files:
 
         os.makedirs(output_folder, exist_ok=True)
 
-        parallel_files = min(parallel_files, 3)
+        parallel_files = min(parallel_files, 3, len(urls))
         failures: List[Tuple[str, str]] = []
         if parallel_files < 2:
             for url in urls:

--- a/pridepy/files/files.py
+++ b/pridepy/files/files.py
@@ -622,7 +622,7 @@ class Files:
         )
 
         # --- Phase 1: download (skip check already done, pass False) ---------
-        parallel_files = min(parallel_files, 3)
+        parallel_files = min(parallel_files, 3, len(files_to_download))
         if parallel_files < 2:
             for file in files_to_download:
                 try:

--- a/pridepy/tests/test_download_resilience.py
+++ b/pridepy/tests/test_download_resilience.py
@@ -215,6 +215,45 @@ class TestDownloadResilience(TestCase):
             assert batch_mock.call_args.args[2] == "ftp"
             fallback_mock.assert_not_called()
 
+    def test_globus_parallel_workers_capped_to_file_count(self):
+        """When parallel_files exceeds the number of files to download,
+        the worker pool must not allocate more threads than files."""
+        file_records = [
+            {
+                "fileName": "only.raw",
+                "publicFileLocations": [
+                    {"name": "FTP Protocol",
+                     "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2024/01/PXD000001/only.raw"}
+                ],
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch.object(Files, "_globus_download_one") as mock_one:
+                Files.download_files_from_globus(
+                    file_list_json=file_records,
+                    output_folder=tmp_dir,
+                    skip_if_downloaded_already=False,
+                    parallel_files=3,
+                )
+                # With 1 file and parallel_files=3, should fall through to
+                # the serial path (parallel_files capped to 1 < 2).
+                mock_one.assert_called_once()
+
+    def test_url_parallel_workers_capped_to_url_count(self):
+        """download_files_by_url must cap workers to len(urls)."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch.object(Files, "_download_single_url") as mock_single:
+                Files.download_files_by_url(
+                    urls=["https://example.org/a.raw"],
+                    output_folder=tmp_dir,
+                    skip_if_downloaded_already=False,
+                    protocol="globus",
+                    parallel_files=3,
+                )
+                # 1 URL with parallel_files=3 → capped to 1, serial path.
+                mock_single.assert_called_once()
+
     def test_download_files_raises_when_any_file_fails(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             file_list = [{"fileName": "missing.raw"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pridepy"
-version = "0.0.14"
+version = "0.0.15"
 description = "Python Client library for PRIDE Rest API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
This pull request makes a minor improvement to the file download logic in `pridepy` and bumps the package version. The main change ensures that the number of parallel downloads does not exceed the number of files to download, preventing unnecessary resource allocation.

- File download logic improvement:
  * [`pridepy/files/files.py`](diffhunk://#diff-a841f149293bacff57c3547e07605f2675a770c627d4c4be1b549866d81c15a5L625-R625): The calculation of `parallel_files` now also considers the number of files to download, ensuring it does not exceed the available files.

- Version update:
  * [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Bumped the package version from `0.0.14` to `0.0.15`.