### PR TITLE
Add --version flag to CLI

### DIFF
--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -9,6 +9,7 @@ PROTOCOL_CHOICES = click.Choice(["ftp", "aspera", "globus", "s3"], case_sensitiv
 
 
 @click.group()
+@click.version_option(package_name="pridepy")
 def main():
     pass
 


### PR DESCRIPTION
## Summary

- Adds a `--version` flag to the `pridepy` CLI by attaching `@click.version_option(package_name="pridepy")` to the root command group.
- Reads the version from installed package metadata (no hard-coded version string), so it stays in sync with the package release automatically.
- Previously the CLI had no way to report its version, which made debugging user-reported issues harder.

## Test plan

- [ ] `pip install -e .` from the repo root
- [ ] `pridepy --version` prints `pridepy, version <X.Y.Z>` matching the installed package metadata
- [ ] `pridepy --help` still lists all existing subcommands unchanged