### PR TITLE
Add direct download support for MassIVE accessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 You can:
 - download public and private PRIDE files
+- download public MassIVE datasets directly from `MSV...` accessions
 - download by category (`RAW`, `SEARCH`, `RESULT`, etc.)
 - stream project and file metadata
 - search projects by keyword and filters
@@ -79,7 +80,17 @@ pridepy download-all-public-raw-files \
   --checksum-check
 ```
 
-### 3) Download only selected categories
+### 3) Download a public MassIVE dataset directly
+
+```bash
+pridepy download-all-public-raw-files \
+  -a MSV000082297 \
+  -o ./downloads/MSV000082297
+```
+
+For direct `MSV...` downloads, `pridepy` enumerates the dataset from MassIVE's public FTP tree. Raw downloads follow MassIVE's own collection layout, so `download-all-public-raw-files` downloads the files stored under the dataset's `raw/` collection.
+
+### 4) Download only selected categories
 
 ```bash
 pridepy download-all-public-category-files \
@@ -88,7 +99,16 @@ pridepy download-all-public-category-files \
   -c RAW,SEARCH
 ```
 
-### 4) Download one file by name
+You can also request a specific MassIVE collection through the same category interface:
+
+```bash
+pridepy download-all-public-category-files \
+  -a MSV000082297 \
+  -o ./downloads/MSV000082297-results \
+  -c RESULT
+```
+
+### 5) Download one file by name
 
 ```bash
 pridepy download-file-by-name \
@@ -98,7 +118,7 @@ pridepy download-file-by-name \
   --checksum-check
 ```
 
-### 5) Download raw files from ProteomeXchange
+### 6) Download raw files from ProteomeXchange
 
 ```bash
 pridepy download-px-raw-files \
@@ -177,6 +197,16 @@ files = Files()
 raw_files = files.get_all_raw_file_list("PXD008644")
 print(f"RAW files: {len(raw_files)}")
 print(raw_files[0]["fileName"])
+```
+
+For MassIVE accessions, the same method returns the files found under the dataset's `raw/` collection:
+
+```python
+from pridepy.files.files import Files
+
+files = Files()
+raw_files = files.get_all_raw_file_list("MSV000082297")
+print(f"MassIVE raw files: {len(raw_files)}")
 ```
 
 ### Example: search projects

--- a/pridepy/files/files.py
+++ b/pridepy/files/files.py
@@ -1367,7 +1367,7 @@ class Files:
         delegates to :meth:`download_files` so the existing batch + protocol
         fallback engine is reused.
 
-        :param accession: PRIDE project accession (public)
+        :param accession: PRIDE or MassIVE project accession (public)
         :param file_names: filenames to download
         :param output_folder: directory to write downloaded files into
         :param skip_if_downloaded_already: skip files already present locally
@@ -1380,7 +1380,10 @@ class Files:
         if not file_names:
             raise ValueError("file_names must contain at least one filename")
 
-        all_files = self.stream_all_files_by_project(accession)
+        if self.is_massive_accession(accession):
+            all_files = self._list_massive_public_files(accession)
+        else:
+            all_files = self.stream_all_files_by_project(accession)
         requested = set(file_names)
         matched = [f for f in all_files if f.get("fileName") in requested]
         missing = sorted(requested - {f.get("fileName") for f in matched})
@@ -1390,6 +1393,16 @@ class Files:
             raise ValueError(
                 f"No matching files in project {accession} for: {sorted(requested)}"
             )
+
+        if self.is_massive_accession(accession):
+            self._download_massive_file_records(
+                accession=accession,
+                file_records=matched,
+                output_folder=output_folder,
+                skip_if_downloaded_already=skip_if_downloaded_already,
+                protocol=protocol,
+            )
+            return
 
         self.download_files(
             matched,

--- a/pridepy/files/files.py
+++ b/pridepy/files/files.py
@@ -5,6 +5,7 @@ import importlib.resources
 import logging
 import os
 import platform
+import posixpath
 import re
 import subprocess
 import urllib
@@ -58,10 +59,24 @@ class Files:
     API_PRIVATE_URL = "https://www.ebi.ac.uk/pride/private/ws/archive/v2"
     PRIDE_ARCHIVE_FTP = "ftp.pride.ebi.ac.uk"
     PRIDE_ARCHIVE_FTP_URL_PREFIX = "ftp://ftp.pride.ebi.ac.uk/"
+    MASSIVE_ARCHIVE_FTP = "massive-ftp.ucsd.edu"
+    MASSIVE_ARCHIVE_FTP_URL_PREFIX = "ftp://massive-ftp.ucsd.edu/v01/"
     GLOBUS_BASE_URL = "https://g-a8b222.dd271.03c0.data.globus.org/"
     S3_URL = "https://hh.fire.sdo.ebi.ac.uk"
     S3_BUCKET = "pride-public"
     PROTOCOL_ORDER = ["aspera", "s3", "ftp", "globus"]
+    MASSIVE_CATEGORY_MAP = {
+        "raw": "RAW",
+        "peak": "PEAK",
+        "ccms_peak": "PEAK",
+        "search": "SEARCH",
+        "result": "RESULT",
+        "ccms_result": "RESULT",
+        "quant": "RESULT",
+        "fasta": "FASTA",
+        "spectrum_library": "SPECTRUM_LIBRARY",
+        "library": "SPECTRUM_LIBRARY",
+    }
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
     def __init__(self):
@@ -225,6 +240,150 @@ class Files:
             return []
         return [protocol] + [p for p in Files.PROTOCOL_ORDER if p != protocol]
 
+    @staticmethod
+    def is_massive_accession(accession: str) -> bool:
+        """
+        Return True when the accession looks like a MassIVE dataset accession.
+        """
+        if not accession:
+            return False
+        return bool(re.fullmatch(r"R?MSV\d{9}", accession.upper()))
+
+    @staticmethod
+    def _get_massive_public_root(accession: str) -> str:
+        normalized_accession = accession.upper()
+        return f"/v01/{normalized_accession}"
+
+    @staticmethod
+    def _get_massive_public_ftp_url(accession: str, remote_path: str) -> str:
+        root_path = Files._get_massive_public_root(accession).rstrip("/")
+        relative_path = remote_path
+        if remote_path.startswith(root_path):
+            relative_path = remote_path[len(root_path) :].lstrip("/")
+        return f"{Files.MASSIVE_ARCHIVE_FTP_URL_PREFIX}{accession.upper()}/{relative_path}"
+
+    @staticmethod
+    def _map_massive_collection_to_category(collection: str) -> str:
+        return Files.MASSIVE_CATEGORY_MAP.get(collection.lower(), "OTHER")
+
+    @staticmethod
+    def _build_massive_file_record(accession: str, ftp_url: str) -> Dict:
+        parsed = urlparse(ftp_url)
+        root_prefix = f"/v01/{accession.upper()}/"
+        relative_path = parsed.path
+        if relative_path.startswith(root_prefix):
+            relative_path = relative_path[len(root_prefix) :]
+        relative_path = relative_path.lstrip("/")
+        collection = relative_path.split("/", 1)[0] if relative_path else ""
+        return {
+            "accession": accession.upper(),
+            "fileName": os.path.basename(parsed.path),
+            "fileCategory": {"value": Files._map_massive_collection_to_category(collection)},
+            "publicFileLocations": [{"name": "FTP Protocol", "value": ftp_url}],
+            "relativePath": relative_path,
+            "collection": collection,
+            "source": "MassIVE",
+        }
+
+    @staticmethod
+    def _walk_ftp_tree(ftp: FTP, remote_dir: str) -> List[str]:
+        """
+        Recursively list files under a remote FTP directory.
+        """
+        file_paths: List[str] = []
+        try:
+            entries = list(ftp.mlsd(remote_dir))
+            for name, facts in entries:
+                if name in {".", ".."}:
+                    continue
+                child_path = posixpath.join(remote_dir.rstrip("/"), name)
+                if facts.get("type") == "dir":
+                    file_paths.extend(Files._walk_ftp_tree(ftp, child_path))
+                elif facts.get("type") == "file":
+                    file_paths.append(child_path)
+            return file_paths
+        except (AttributeError, ftplib.error_perm):
+            pass
+
+        current_dir = ftp.pwd()
+        listing: List[str] = []
+        try:
+            ftp.cwd(remote_dir)
+            ftp.retrlines("LIST", listing.append)
+            for entry in listing:
+                parts = entry.split(maxsplit=8)
+                if len(parts) < 9:
+                    continue
+                name = parts[8]
+                if name in {".", ".."}:
+                    continue
+                child_path = posixpath.join(remote_dir.rstrip("/"), name)
+                if entry.startswith("d"):
+                    file_paths.extend(Files._walk_ftp_tree(ftp, child_path))
+                else:
+                    file_paths.append(child_path)
+        finally:
+            ftp.cwd(current_dir)
+        return file_paths
+
+    def _list_massive_public_files(self, accession: str) -> List[Dict]:
+        """
+        Discover all public files for a MassIVE dataset from its anonymous FTP tree.
+        """
+        normalized_accession = accession.upper()
+        remote_root = self._get_massive_public_root(normalized_accession)
+        ftp = FTP(self.MASSIVE_ARCHIVE_FTP, timeout=30)
+        try:
+            ftp.login()
+            ftp.set_pasv(True)
+            logging.info(f"Connected to FTP host: {self.MASSIVE_ARCHIVE_FTP}")
+            remote_files = self._walk_ftp_tree(ftp, remote_root)
+        except Exception as error:
+            raise RuntimeError(
+                f"Unable to list public files for MassIVE dataset {normalized_accession}: {error}"
+            ) from error
+        finally:
+            try:
+                ftp.quit()
+            except Exception:
+                ftp.close()
+
+        return [
+            self._build_massive_file_record(
+                normalized_accession,
+                self._get_massive_public_ftp_url(normalized_accession, remote_file),
+            )
+            for remote_file in remote_files
+        ]
+
+    def _download_massive_file_records(
+        self,
+        accession: str,
+        file_records: List[Dict],
+        output_folder: str,
+        skip_if_downloaded_already: bool,
+        protocol: str,
+    ) -> None:
+        """
+        Download public MassIVE files via anonymous FTP.
+        """
+        if protocol != "ftp":
+            logging.warning(
+                "MassIVE direct downloads currently use ftp only. "
+                f"Ignoring requested protocol '{protocol}' for {accession}."
+            )
+
+        ftp_urls = [self._get_download_url(file_record, "ftp") for file_record in file_records]
+        if not ftp_urls:
+            logging.info(f"No files matched for MassIVE dataset {accession}")
+            return
+
+        self.download_ftp_urls(
+            ftp_urls=ftp_urls,
+            output_folder=output_folder,
+            skip_if_downloaded_already=skip_if_downloaded_already,
+        )
+
     async def stream_all_files_metadata(self, output_file, accession=None):
         """
         get stream all project files from PRIDE API in JSON format
@@ -259,6 +418,11 @@ class Files:
         :param project_accession: PRIDE accession
         :return: raw file list in JSON format
         """
+        if self.is_massive_accession(project_accession):
+            record_files = self._list_massive_public_files(project_accession)
+            return [
+                file for file in record_files if file["fileCategory"]["value"] == "RAW"
+            ]
 
         record_files = self.stream_all_files_by_project(project_accession)
 
@@ -290,6 +454,16 @@ class Files:
             os.mkdir(output_folder)
 
         raw_files = self.get_all_raw_file_list(accession)
+
+        if self.is_massive_accession(accession):
+            self._download_massive_file_records(
+                accession=accession,
+                file_records=raw_files,
+                output_folder=output_folder,
+                skip_if_downloaded_already=skip_if_downloaded_already,
+                protocol=protocol,
+            )
+            return
 
         self.download_files(
             raw_files,
@@ -353,9 +527,8 @@ class Files:
                             continue
 
                         # Extract file path from the download URL
-                        ftp_file_path = download_url.replace(
-                            f"ftp://{Files.PRIDE_ARCHIVE_FTP}/", ""
-                        )
+                        parsed_url = urlparse(download_url)
+                        ftp_file_path = urllib.parse.unquote(parsed_url.path.lstrip("/"))
 
                         logging.info(f"Starting FTP download: {ftp_file_path}")
 
@@ -658,6 +831,22 @@ class Files:
             os.mkdir(output_folder)
 
         ## Check type of project
+        if self.is_massive_accession(accession):
+            logging.info("Downloading file from public MassIVE dataset {}".format(accession))
+            response = self.get_file_from_api(accession, file_name)
+            if not response:
+                raise Exception(
+                    "File name {} not found in MassIVE dataset {}".format(file_name, accession)
+                )
+            self._download_massive_file_records(
+                accession=accession,
+                file_records=response,
+                output_folder=output_folder,
+                skip_if_downloaded_already=skip_if_downloaded_already,
+                protocol=protocol,
+            )
+            return
+
         public_project = False
         project_status = Util.get_api_call(self.API_BASE_URL + "/status/{}".format(accession))
 
@@ -711,6 +900,9 @@ class Files:
         """
 
         try:
+            if self.is_massive_accession(accession):
+                files = self._list_massive_public_files(accession)
+                return [f for f in files if f["fileName"] == file_name]
             files = self.stream_all_files_by_project(accession)
             file = [f for f in files if f["fileName"] == file_name]
             return file
@@ -1056,6 +1248,15 @@ class Files:
         if categories is None:
             categories = [category] if category else ["RAW"]
         raw_files = self.get_all_category_file_list(accession, categories)
+        if self.is_massive_accession(accession):
+            self._download_massive_file_records(
+                accession=accession,
+                file_records=raw_files,
+                output_folder=output_folder,
+                skip_if_downloaded_already=skip_if_downloaded_already,
+                protocol=protocol,
+            )
+            return
         self.download_files(
             raw_files,
             accession,
@@ -1076,10 +1277,15 @@ class Files:
         :param categories: A single category string or list of categories to filter by.
         :return: A list of files matching the specified categories.
         """
-        record_files = self.stream_all_files_by_project(accession)
         if isinstance(categories, str):
             categories = [categories]
-        category_set = set(categories)
+        category_set = {category.upper() for category in categories}
+
+        if self.is_massive_accession(accession):
+            record_files = self._list_massive_public_files(accession)
+        else:
+            record_files = self.stream_all_files_by_project(accession)
+
         category_files = [
             file for file in record_files if file["fileCategory"]["value"] in category_set
         ]

--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -56,7 +56,7 @@ def main():
     "--parallel-files",
     default=1,
     type=click.IntRange(1, 3),
-    help="Number of files to download simultaneously for globus (1-3). Default is 1.",
+    help="Number of files to download simultaneously (1-3). Primarily used by globus protocol. Default is 1.",
 )
 def download_all_public_raw_files(
     accession,
@@ -147,7 +147,7 @@ def download_all_public_raw_files(
     "--parallel-files",
     default=1,
     type=click.IntRange(1, 3),
-    help="Number of files to download simultaneously for globus (1-3). Default is 1.",
+    help="Number of files to download simultaneously (1-3). Primarily used by globus protocol. Default is 1.",
 )
 def download_all_public_category_files(
     accession: str,
@@ -559,7 +559,7 @@ def _read_url_arguments(url_list_path, urls_csv=None):
     "--parallel-files",
     default=1,
     type=click.IntRange(1, 3),
-    help="Number of files to download simultaneously for globus (1-3). Default is 1.",
+    help="Number of files to download simultaneously (1-3). Primarily used by globus protocol. Default is 1.",
 )
 def download_files_by_list(
     accession,
@@ -640,7 +640,7 @@ def download_files_by_list(
     "--parallel-files",
     default=1,
     type=click.IntRange(1, 3),
-    help="Number of files to download simultaneously for globus (1-3). Default is 1.",
+    help="Number of files to download simultaneously (1-3). Primarily used by globus protocol. Default is 1.",
 )
 def download_files_by_url(
     url_list_path,

--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -15,9 +15,9 @@ def main():
 
 @main.command(
     "download-all-public-raw-files",
-    help="Download all public raw files from a given PRIDE public project",
+    help="Download all public raw files from a PRIDE or MassIVE public dataset",
 )
-@click.option("-a", "--accession", required=True, help="PRIDE project accession")
+@click.option("-a", "--accession", required=True, help="PRIDE or MassIVE accession")
 @click.option(
     "-p",
     "--protocol",
@@ -59,10 +59,10 @@ def download_all_public_raw_files(
     checksum_check: bool = False,
 ):
     """
-    Command to download all public raw files from a specified PRIDE project.
+    Command to download all public raw files from a specified PRIDE or MassIVE dataset.
 
     Parameters:
-        accession (str): PRIDE project accession.
+        accession (str): PRIDE or MassIVE accession.
         protocol (str): Protocol for downloading files (ftp, aspera, globus, s3). Default is ftp.
         output_folder (str): Directory to save downloaded raw files.
         skip_if_downloaded_already (bool): Skip download if files already exist. Default is False.
@@ -89,9 +89,9 @@ def download_all_public_raw_files(
 
 @main.command(
     "download-all-public-category-files",
-    help="Download all public files of specific category from a given PRIDE public project",
+    help="Download all public files of specific category from a PRIDE or MassIVE public dataset",
 )
-@click.option("-a", "--accession", required=True, help="PRIDE project accession")
+@click.option("-a", "--accession", required=True, help="PRIDE or MassIVE accession")
 @click.option(
     "-p",
     "--protocol",
@@ -141,10 +141,10 @@ def download_all_public_category_files(
     category: str = "RAW",
 ):
     """
-    Command to download all public files of a specified category from a given PRIDE public project.
+    Command to download all public files of a specified category from a given PRIDE or MassIVE dataset.
 
     Parameters:
-        accession (str): The PRIDE project accession identifier.
+        accession (str): The PRIDE or MassIVE dataset accession identifier.
         protocol (str): The protocol to use for downloading files (ftp, aspera, globus, s3).
         output_folder (str): The directory where the files will be downloaded.
         skip_if_downloaded_already (bool): If True, skips downloading files that already exist. Default is False.
@@ -182,9 +182,9 @@ def download_all_public_category_files(
 
 @main.command(
     "download-file-by-name",
-    help="Download a single file from a given PRIDE project (public or private)",
+    help="Download a single file from a PRIDE dataset or a public MassIVE dataset",
 )
-@click.option("-a", "--accession", required=True, help="PRIDE project accession")
+@click.option("-a", "--accession", required=True, help="PRIDE or MassIVE accession")
 @click.option(
     "-p",
     "--protocol",
@@ -233,7 +233,7 @@ def download_file_by_name(
 ):
     """
     This script download single file from servers or copy from the file system
-    :param accession: PRIDE project accession
+    :param accession: PRIDE or MassIVE accession
     :param protocol: Protocol to use for download: ftp, aspera, globus, s3. Default is ftp.
     :param file_name: fileName to be downloaded
     :param output_folder: output folder to download or copy files

--- a/pridepy/tests/test_massive_files.py
+++ b/pridepy/tests/test_massive_files.py
@@ -1,0 +1,102 @@
+import tempfile
+from unittest import TestCase
+from unittest.mock import patch
+
+from pridepy.files.files import Files
+
+
+class TestMassIVEFiles(TestCase):
+    def test_is_massive_accession(self):
+        assert Files.is_massive_accession("MSV000012345")
+        assert Files.is_massive_accession("rmsv000012345")
+        assert not Files.is_massive_accession("PXD000012")
+        assert not Files.is_massive_accession("MSV123")
+
+    def test_build_massive_file_record_maps_collection_to_category(self):
+        record = Files._build_massive_file_record(
+            "MSV000012345",
+            "ftp://massive-ftp.ucsd.edu/v01/MSV000012345/ccms_peak/converted/sample.mzML",
+        )
+
+        assert record["fileName"] == "sample.mzML"
+        assert record["collection"] == "ccms_peak"
+        assert record["fileCategory"]["value"] == "PEAK"
+
+    def test_build_massive_file_record_marks_raw_collection_as_raw(self):
+        record = Files._build_massive_file_record(
+            "MSV000012345",
+            "ftp://massive-ftp.ucsd.edu/v01/MSV000012345/raw/run01.raw",
+        )
+
+        assert record["collection"] == "raw"
+        assert record["fileCategory"]["value"] == "RAW"
+
+    def test_build_massive_file_record_keeps_non_raw_collection_even_for_raw_like_file_names(self):
+        record = Files._build_massive_file_record(
+            "MSV000012345",
+            "ftp://massive-ftp.ucsd.edu/v01/MSV000012345/uploads/run01.raw",
+        )
+
+        assert record["collection"] == "uploads"
+        assert record["fileCategory"]["value"] == "OTHER"
+
+    def test_build_massive_file_record_marks_ab_sciex_scan_sidecar_as_raw_when_under_raw(self):
+        record = Files._build_massive_file_record(
+            "MSV000012345",
+            "ftp://massive-ftp.ucsd.edu/v01/MSV000012345/raw/sample.wiff.scan",
+        )
+
+        assert record["collection"] == "raw"
+        assert record["fileCategory"]["value"] == "RAW"
+
+    def test_get_all_raw_file_list_filters_massive_records(self):
+        files = Files()
+        massive_records = [
+            Files._build_massive_file_record(
+                "MSV000012345",
+                "ftp://massive-ftp.ucsd.edu/v01/MSV000012345/raw/run1.raw",
+            ),
+            Files._build_massive_file_record(
+                "MSV000012345",
+                "ftp://massive-ftp.ucsd.edu/v01/MSV000012345/quant/results.tsv",
+            ),
+            Files._build_massive_file_record(
+                "MSV000012345",
+                "ftp://massive-ftp.ucsd.edu/v01/MSV000012345/uploads/run2.mzML",
+            ),
+        ]
+
+        with patch.object(Files, "_list_massive_public_files", return_value=massive_records):
+            result = files.get_all_raw_file_list("MSV000012345")
+
+        assert len(result) == 1
+        assert {file["fileName"] for file in result} == {"run1.raw"}
+
+    def test_download_file_by_name_uses_massive_ftp_listing(self):
+        files = Files()
+        file_record = Files._build_massive_file_record(
+            "MSV000012345",
+            "ftp://massive-ftp.ucsd.edu/v01/MSV000012345/raw/folder/sample.raw",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch.object(Files, "_list_massive_public_files", return_value=[file_record]), patch.object(
+                Files, "download_ftp_urls"
+            ) as download_mock:
+                files.download_file_by_name(
+                    accession="MSV000012345",
+                    file_name="sample.raw",
+                    output_folder=tmp_dir,
+                    skip_if_downloaded_already=False,
+                    protocol="ftp",
+                    username=None,
+                    password=None,
+                    aspera_maximum_bandwidth="100M",
+                    checksum_check=False,
+                )
+
+        download_mock.assert_called_once_with(
+            ftp_urls=["ftp://massive-ftp.ucsd.edu/v01/MSV000012345/raw/folder/sample.raw"],
+            output_folder=tmp_dir,
+            skip_if_downloaded_already=False,
+        )


### PR DESCRIPTION
Summary
- add direct public download support for MassIVE MSV accessions by enumerating the dataset on MassIVE FTP
- route raw, category, and single-file download flows through the MassIVE FTP path when the accession is from MassIVE
- document the new behavior in the README, including that raw downloads follow MassIVE's raw collection layout, and add regression tests for the new code path

Testing
- uv run pytest pridepy/tests/test_massive_files.py pridepy/tests/test_download_resilience.py
