### PR TITLE
fix(massive/ftp): emit progress while walking the FTPS tree

### DIFF
--- a/pridepy/download/transport.py
+++ b/pridepy/download/transport.py
@@ -83,22 +83,59 @@ def _open_ftp_connection(host: str, use_tls: bool, timeout: int = 30) -> FTP:
     return ftp
 
 
-def _walk_ftp_tree(ftp: FTP, remote_dir: str) -> List[str]:
+# Emit a progress line every this many directories while walking a remote
+# tree. Large deposits (e.g. a MassIVE timsTOF dataset with thousands of .d
+# directories, each needing its own TLS data connection to list) can take
+# many minutes to enumerate; without progress the caller looks hung.
+_WALK_PROGRESS_EVERY_DIRS = 100
+
+
+def _walk_ftp_tree(
+    ftp: FTP, remote_dir: str, _progress: Optional[dict] = None
+) -> List[str]:
     """
     Recursively list files under a remote FTP directory.
+
+    Emits an INFO progress heartbeat every ``_WALK_PROGRESS_EVERY_DIRS``
+    directories, plus a final summary, so enumerating a large deposit does
+    not look like a hang. ``_progress`` is internal recursion state; callers
+    invoke this with ``(ftp, remote_dir)`` only.
     """
     import posixpath
+
+    top_level = _progress is None
+    if top_level:
+        _progress = {"dirs": 0, "files": 0}
+
+    def _note_dir_listed() -> None:
+        _progress["dirs"] += 1
+        if _progress["dirs"] % _WALK_PROGRESS_EVERY_DIRS == 0:
+            logging.info(
+                "Listing remote tree: %d directories scanned, "
+                "%d files found so far...",
+                _progress["dirs"],
+                _progress["files"],
+            )
+
     file_paths: List[str] = []
     try:
         entries = list(ftp.mlsd(remote_dir))
+        _note_dir_listed()
         for name, facts in entries:
             if name in {".", ".."}:
                 continue
             child_path = posixpath.join(remote_dir.rstrip("/"), name)
             if facts.get("type") == "dir":
-                file_paths.extend(_walk_ftp_tree(ftp, child_path))
+                file_paths.extend(_walk_ftp_tree(ftp, child_path, _progress))
             elif facts.get("type") == "file":
                 file_paths.append(child_path)
+                _progress["files"] += 1
+        if top_level:
+            logging.info(
+                "Listing remote tree complete: %d directories, %d files.",
+                _progress["dirs"],
+                _progress["files"],
+            )
         return file_paths
     except (AttributeError, ftplib.error_perm):
         pass
@@ -108,6 +145,7 @@ def _walk_ftp_tree(ftp: FTP, remote_dir: str) -> List[str]:
     try:
         ftp.cwd(remote_dir)
         ftp.retrlines("LIST", listing.append)
+        _note_dir_listed()
         for entry in listing:
             parts = entry.split(maxsplit=8)
             if len(parts) < 9:
@@ -117,11 +155,18 @@ def _walk_ftp_tree(ftp: FTP, remote_dir: str) -> List[str]:
                 continue
             child_path = posixpath.join(remote_dir.rstrip("/"), name)
             if entry.startswith("d"):
-                file_paths.extend(_walk_ftp_tree(ftp, child_path))
+                file_paths.extend(_walk_ftp_tree(ftp, child_path, _progress))
             else:
                 file_paths.append(child_path)
+                _progress["files"] += 1
     finally:
         ftp.cwd(current_dir)
+    if top_level:
+        logging.info(
+            "Listing remote tree complete: %d directories, %d files.",
+            _progress["dirs"],
+            _progress["files"],
+        )
     return file_paths
 
 


### PR DESCRIPTION
## Problem

For large MassIVE deposits, `pridepy download-all-public-raw-files` appears to
hang after connecting. Example with `MSV000098940` (timsTOF, 1719 `.d`):

```
INFO - Data will be downloaded from ftp
INFO - Connected to FTP host: massive-ftp.ucsd.edu (tls=True)
INFO - Found MSV000098940 under /v10/MSV000098940 on massive-ftp.ucsd.edu
<… long silence, no output … user assumes it hung and Ctrl-C's …>
```

This is **not** a TLS/connection problem (FTPS connects fine) and **not** a
missing-protocol problem. The MassIVE provider calls `list_files` →
`_resolve_and_walk_ftp_dataset` → `_walk_ftp_tree`, which **enumerates the
entire tree before any download begins**: it lists `raw/` (1719 `.d`) and then
descends into every `.d` and its nested `.m/`. Each listing is a fresh
PASV+TLS data connection (~2.2 s each), so the pre-walk alone takes:

```
top-level LIST: 1719 .d dirs in 1.8s
recursed 20 .d (40 LISTs) in 43.3s  -> 2.17s per .d
=> full walk of 1719 .d ≈ 62 min of silent enumeration BEFORE any download
```

With no output during those ~62 minutes, the run looks dead.

## Fix

Emit an INFO progress heartbeat from `_walk_ftp_tree` every 100 directories,
plus a final summary. This is **pure instrumentation** — the returned file
list and recursion are unchanged. The recursion now threads an internal
`_progress` counter (callers still invoke `_walk_ftp_tree(ftp, remote_dir)`).

New output during a large walk:

```
INFO - Connected to FTP host: massive-ftp.ucsd.edu (tls=True)
INFO - Found MSV000098940 under /v10/MSV000098940 on massive-ftp.ucsd.edu
INFO - Listing remote tree: 100 directories scanned, 95 files found so far...
INFO - Listing remote tree: 200 directories scanned, 195 files found so far...
...
INFO - Listing remote tree complete: 1719 directories, 8500 files.
```

## Testing

- New mock-tree unit check: identical file list returned (recursion intact) and
  heartbeats/summary fire.
- Existing `test_download_resilience.py` + `test_review_fixes.py`: 37 passed.

## Follow-up (not in this PR)

The ~62 min is still spent enumerating before the first byte transfers. A
larger, separate change could **overlap enumeration with download** for MassIVE
(download each top-level `.d` recursively as it is discovered, mirror-style,
like `wget -r`), eliminating the up-front wait entirely. Happy to do that as a
second PR if desired.
