### PR TITLE
fix(iProX Aspera): batched --file-list form (match working ascp); password (env/prompt) or --aspera-key; no batch hang

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -244,11 +244,12 @@ pridepy download-px-raw-files \
 | `-t, --threads` | Parallel HTTP Range threads per file (1–32) for fast per-file downloads | `1` |
 | `--skip-if-downloaded-already` | Skip files already present locally | off |
 | `--preserve-structure` | Recreate the dataset's subdirectory layout under the output folder | off |
-| `--iprox-user` | iProX account username (with `--protocol aspera`; env fallback: `IPROX_USER`) | — |
+| `--iprox-user` | Your registered iProX username (required with `--protocol aspera`; env fallback: `IPROX_USER`) | — |
+| `--aspera-key` | Path to your Aspera private key (required with `--protocol aspera`; env fallback: `IPROX_ASPERA_KEY`) | — |
 
-The iProX Aspera password is never accepted as a command-line flag. Set the
-`IPROX_ASPERA_PASSWORD` environment variable, or omit it and `pridepy` will
-prompt for it securely (hidden input) when `--protocol aspera` is used.
+iProX Aspera uses key-based authentication only — there is no password
+option. `--aspera-key` must point at the private key you registered when
+setting up your Aspera client.
 
 ### Fast downloads: parallel files and per-file segments
 
@@ -279,19 +280,24 @@ pridepy download-px-raw-files \
 ### Fast downloads with iProX Aspera (account required)
 
 iProX offers Aspera for very large bulk transfers. Aspera is faster than HTTP
-on high-bandwidth connections but requires an iProX account. Combine
-`--protocol aspera` with `--iprox-user`; the password is read from
-`IPROX_ASPERA_PASSWORD` or prompted for securely (never passed as a flag):
+on high-bandwidth connections but requires an iProX account and a registered
+Aspera private key (no password auth). Combine `--protocol aspera` with
+`--iprox-user` and `--aspera-key`:
 
 ```bash
-# Download via iProX Aspera with 8-file parallelism
-IPROX_ASPERA_PASSWORD=your_password pridepy download-px-raw-files \
+# Download via iProX Aspera
+pridepy download-px-raw-files \
   -a PXD077178 \
   -o ./out \
   --protocol aspera \
   --iprox-user your_username \
-  -w 8
+  --aspera-key /path/to/your/aspera_key
 ```
+
+Aspera transfers a single batched session per dataset (`ascp --file-list`)
+and always preserves the iProX `IPX.../IPX.../` source directory tree under
+the output folder — `--preserve-structure` / flattening does not apply to
+the Aspera path.
 
 ### Go directly to the hosting repository (native MassIVE / JPOST / iProX accessions)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -245,11 +245,15 @@ pridepy download-px-raw-files \
 | `--skip-if-downloaded-already` | Skip files already present locally | off |
 | `--preserve-structure` | Recreate the dataset's subdirectory layout under the output folder | off |
 | `--iprox-user` | Your registered iProX username (required with `--protocol aspera`; env fallback: `IPROX_USER`) | — |
-| `--aspera-key` | Path to your Aspera private key (required with `--protocol aspera`; env fallback: `IPROX_ASPERA_KEY`) | — |
+| `--aspera-key` | Path to an Aspera private key for iProX (optional with `--protocol aspera`; env fallback: `IPROX_ASPERA_KEY`) | — |
 
-iProX Aspera uses key-based authentication only — there is no password
-option. `--aspera-key` must point at the private key you registered when
-setting up your Aspera client.
+iProX Aspera defaults to password authentication (your iProX account
+password), supplied via the `IPROX_ASPERA_PASSWORD` env var or an
+interactive hidden prompt. Pass `--aspera-key` instead if you have a
+registered Aspera private key. Exactly one credential is required —
+`pridepy` fails fast rather than letting `ascp` block on an interactive
+prompt, so batch/sbatch jobs must set `IPROX_ASPERA_PASSWORD` (or
+`--aspera-key`) up front.
 
 ### Fast downloads: parallel files and per-file segments
 
@@ -280,19 +284,24 @@ pridepy download-px-raw-files \
 ### Fast downloads with iProX Aspera (account required)
 
 iProX offers Aspera for very large bulk transfers. Aspera is faster than HTTP
-on high-bandwidth connections but requires an iProX account and a registered
-Aspera private key (no password auth). Combine `--protocol aspera` with
-`--iprox-user` and `--aspera-key`:
+on high-bandwidth connections but requires an iProX account. Combine
+`--protocol aspera` with `--iprox-user` and a credential — either the
+`IPROX_ASPERA_PASSWORD` env var (password auth, the default) or
+`--aspera-key` (a registered Aspera private key):
 
 ```bash
-# Download via iProX Aspera
-pridepy download-px-raw-files \
-  -a PXD077178 \
-  -o ./out \
-  --protocol aspera \
-  --iprox-user your_username \
-  --aspera-key /path/to/your/aspera_key
+# password auth (env var — safe for sbatch; no prompt/hang)
+IPROX_ASPERA_PASSWORD=... pridepy download-px-raw-files -a PXD077178 -o ./out --protocol aspera --iprox-user <user>
+
+# or with a registered key
+pridepy download-px-raw-files -a PXD077178 -o ./out --protocol aspera --iprox-user <user> --aspera-key /path/to/key
 ```
+
+If run interactively without `IPROX_ASPERA_PASSWORD` or `--aspera-key`,
+`pridepy` prompts for the password (hidden input). In non-interactive/batch
+contexts (e.g. `sbatch`) you must set `IPROX_ASPERA_PASSWORD` or pass
+`--aspera-key` up front — otherwise the command errors immediately instead
+of hanging on a prompt.
 
 Aspera transfers a single batched session per dataset (`ascp --file-list`)
 and always preserves the iProX `IPX.../IPX.../` source directory tree under

--- a/pridepy/download/client.py
+++ b/pridepy/download/client.py
@@ -322,7 +322,7 @@ class Client:
         download_threads: int = 1,
         protocol: str = "ftp",
         iprox_user: Optional[str] = None,
-        iprox_password: Optional[str] = None,
+        aspera_key: Optional[str] = None,
     ) -> None:
         """Delegate to :meth:`ProteomeXchangeProvider.download_from_accession_or_url`."""
         return ProteomeXchangeProvider().download_from_accession_or_url(
@@ -334,5 +334,5 @@ class Client:
             download_threads=download_threads,
             protocol=protocol,
             iprox_user=iprox_user,
-            iprox_password=iprox_password,
+            aspera_key=aspera_key,
         )

--- a/pridepy/download/client.py
+++ b/pridepy/download/client.py
@@ -323,6 +323,7 @@ class Client:
         protocol: str = "ftp",
         iprox_user: Optional[str] = None,
         aspera_key: Optional[str] = None,
+        aspera_password: Optional[str] = None,
     ) -> None:
         """Delegate to :meth:`ProteomeXchangeProvider.download_from_accession_or_url`."""
         return ProteomeXchangeProvider().download_from_accession_or_url(
@@ -335,4 +336,5 @@ class Client:
             protocol=protocol,
             iprox_user=iprox_user,
             aspera_key=aspera_key,
+            aspera_password=aspera_password,
         )

--- a/pridepy/download/iprox.py
+++ b/pridepy/download/iprox.py
@@ -15,7 +15,7 @@ import logging
 import os
 import re
 import subprocess
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import tempfile
 import defusedxml.ElementTree as ET
 from typing import ClassVar, Dict, List, Optional
 from urllib.parse import urlparse
@@ -25,7 +25,6 @@ import requests
 from pridepy.download import registry
 from pridepy.download.base import Provider
 from pridepy.download.jpost import JpostProvider
-from pridepy.download.transport import _safe_join
 
 
 @registry.register
@@ -39,7 +38,6 @@ class IproxProvider(Provider):
     )
     ASPERA_HOST: ClassVar[str] = "download.iprox.org"
     ASPERA_PORT: ClassVar[str] = "33001"
-    ASPERA_ROOT: ClassVar[str] = "/data/iprox"
     # iProX PX XML uses the same PSI-MS cvParam "name" values as JPOST PROXI,
     # so we reuse JpostProvider's category map.
     PX_CATEGORY_MAP: ClassVar[Dict[str, str]] = JpostProvider.PROXI_CATEGORY_MAP
@@ -58,126 +56,59 @@ class IproxProvider(Provider):
         return PrideProvider.get_ascp_binary()
 
     @classmethod
-    def _aspera_download_one(
-        cls,
-        ascp: str,
-        url: str,
-        relpath: Optional[str],
-        output_folder: str,
-        user: str,
-        password: str,
-        maximum_bandwidth: str,
-        skip_if_downloaded_already: bool,
-        env: Dict[str, str],
-    ) -> Optional[str]:
-        """Download a single URL via ascp. Returns ``url`` on failure, else None."""
-        path = urlparse(url).path.lstrip("/")  # e.g. IPX.../.../a.raw
-        source = f"{user}@{cls.ASPERA_HOST}:{cls.ASPERA_ROOT}/{path}"
-        if relpath:
-            dest = _safe_join(output_folder, relpath)
-        else:
-            dest = os.path.join(output_folder, os.path.basename(urlparse(url).path))
-        dest_parent = os.path.dirname(dest) or output_folder
-        os.makedirs(dest_parent, exist_ok=True)
-        if (
-            skip_if_downloaded_already
-            and os.path.isfile(dest)
-            and os.path.getsize(dest) > 0
-        ):
-            logging.info(f"Skipping download as file already exists: {dest}")
-            return None
-        argv = [
-            ascp, "-QT", "-P", cls.ASPERA_PORT, "-l", maximum_bandwidth,
-            "-k", "2", source, dest,
-        ]
-        logging.info(
-            "Aspera: %s -> %s", source.replace(password, "***"), dest
-        )
-        try:
-            subprocess.run(argv, check=True, env=env)
-            return None
-        except subprocess.CalledProcessError as e:
-            logging.error(f"iProX Aspera failed for {url}: {e}")
-            return url
-
-    @classmethod
     def aspera_download(
         cls,
         urls: List[str],
         output_folder: str,
-        relative_paths: List[Optional[str]],
         user: Optional[str],
-        password: Optional[str],
-        maximum_bandwidth: str = "100M",
-        skip_if_downloaded_already: bool = False,
-        parallel_files: int = 1,
+        key_path: Optional[str],
+        maximum_bandwidth: str = "500M",
     ) -> None:
-        """Download iProX-hosted URLs via ascp on port 33001.
+        """Download iProX-hosted URLs in one batched ``ascp --file-list`` session.
 
-        Requires iProX account credentials; the password is passed to the
-        subprocess through ASPERA_SCP_PASS (never argv). When
-        ``parallel_files`` > 1, transfers run concurrently: each ``ascp``
-        invocation is its own subprocess writing its own destination file, so
-        this is safe.
+        Uses key-based auth (``-i <key_path>``) against ``download.iprox.org``
+        on port 33001; password auth is not supported. ``ascp --mode recv
+        --file-list`` always recreates the remote ``/IPX.../IPX.../`` source
+        tree under ``output_folder`` — this transfer path does not support
+        flattening.
         """
-        if not user or not password:
+        if not user:
             raise ValueError(
-                "iProX Aspera requires credentials: pass --iprox-user and set "
-                "IPROX_ASPERA_PASSWORD (or answer the password prompt), or use "
-                "the default parallel HTTP transport instead."
+                "iProX Aspera requires --iprox-user (your registered iProX "
+                "username)."
+            )
+        if not key_path or not os.path.isfile(key_path):
+            raise ValueError(
+                "iProX Aspera requires --aspera-key <path> (the path to your "
+                "registered Aspera private key). HTTP is the default "
+                "alternative if you don't have one."
             )
         ascp = cls._ascp_binary()
-        env = dict(os.environ)
-        env["ASPERA_SCP_PASS"] = password
+        remote_paths = [urlparse(u).path for u in urls]
         os.makedirs(output_folder, exist_ok=True)
-        failed: List[str] = []
-        workers = max(1, min(parallel_files, len(urls)))
-        if workers > 1:
-            with ThreadPoolExecutor(max_workers=workers) as executor:
-                future_to_url = {
-                    executor.submit(
-                        cls._aspera_download_one,
-                        ascp,
-                        url,
-                        relative_paths[idx] if idx < len(relative_paths) else None,
-                        output_folder,
-                        user,
-                        password,
-                        maximum_bandwidth,
-                        skip_if_downloaded_already,
-                        env,
-                    ): url
-                    for idx, url in enumerate(urls)
-                }
-                for future in as_completed(future_to_url):
-                    url = future_to_url[future]
-                    try:
-                        result = future.result()
-                        if result is not None:
-                            failed.append(result)
-                    except Exception as e:
-                        logging.error(f"iProX Aspera failed for {url}: {e}")
-                        failed.append(url)
-        else:
-            for idx, url in enumerate(urls):
-                relpath = relative_paths[idx] if idx < len(relative_paths) else None
-                result = cls._aspera_download_one(
-                    ascp,
-                    url,
-                    relpath,
-                    output_folder,
-                    user,
-                    password,
-                    maximum_bandwidth,
-                    skip_if_downloaded_already,
-                    env,
-                )
-                if result is not None:
-                    failed.append(result)
-        if failed:
-            raise RuntimeError(
-                f"iProX Aspera download failed for {len(failed)} file(s): {failed}"
+        fd, list_path = tempfile.mkstemp(prefix="iprox_aspera_", suffix=".txt", text=True)
+        try:
+            with os.fdopen(fd, "w") as fh:
+                for path in remote_paths:
+                    fh.write(path + "\n")
+            argv = [
+                ascp, "-T", "-l", maximum_bandwidth, "-P", cls.ASPERA_PORT,
+                "-k", "1", "-i", key_path, "--mode", "recv",
+                "--host", cls.ASPERA_HOST, "--file-list", list_path,
+                "--user", user, output_folder,
+            ]
+            logging.info(
+                "iProX Aspera: transferring %d file(s) via ascp --file-list",
+                len(remote_paths),
             )
+            try:
+                subprocess.run(argv, check=True)
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(
+                    f"iProX Aspera transfer failed (exit {e.returncode})"
+                ) from e
+        finally:
+            os.remove(list_path)
 
     @staticmethod
     def _get_public_root(accession: str) -> str:

--- a/pridepy/download/iprox.py
+++ b/pridepy/download/iprox.py
@@ -55,33 +55,24 @@ class IproxProvider(Provider):
         from pridepy.download.pride import PrideProvider
         return PrideProvider.get_ascp_binary()
 
-    @staticmethod
-    def _default_aspera_key() -> str:
-        """Path to the public Aspera key bundled with pridepy.
-
-        iProX accepts the standard public Aspera key, so Aspera works with
-        no key setup: users only supply ``--iprox-user``. ``--aspera-key``
-        overrides this when a site requires a different registered key.
-        """
-        import importlib.resources
-        key = importlib.resources.files("pridepy").joinpath(
-            "aspera/key/asperaweb_id_dsa.openssh"
-        )
-        return os.path.abspath(key)
-
     @classmethod
     def aspera_download(
         cls,
         urls: List[str],
         output_folder: str,
         user: Optional[str],
-        key_path: Optional[str],
+        key_path: Optional[str] = None,
+        password: Optional[str] = None,
         maximum_bandwidth: str = "500M",
     ) -> None:
         """Download iProX-hosted URLs in one batched ``ascp --file-list`` session.
 
-        Uses key-based auth (``-i <key_path>``) against ``download.iprox.org``
-        on port 33001; password auth is not supported. ``ascp --mode recv
+        Auth resolution is fail-fast and never lets ``ascp`` fall back to an
+        interactive ``Password:`` prompt (which would hang a batch/sbatch
+        job): pass ``key_path`` for key-based auth (``-i <key_path>``), or
+        ``password`` for password auth (via the ``ASPERA_SCP_PASS``
+        env var — iProX's own account password, not a key). Exactly one of
+        the two must be supplied by the caller. ``ascp --mode recv
         --file-list`` always recreates the remote ``/IPX.../IPX.../`` source
         tree under ``output_folder`` — this transfer path does not support
         flattening.
@@ -91,13 +82,21 @@ class IproxProvider(Provider):
                 "iProX Aspera requires --iprox-user (your registered iProX "
                 "username)."
             )
-        if not key_path:
-            key_path = cls._default_aspera_key()
-        if not os.path.isfile(key_path):
+        env = dict(os.environ)
+        if key_path:
+            if not os.path.isfile(key_path):
+                raise ValueError(
+                    f"iProX Aspera key not found: {key_path}. Pass "
+                    "--aspera-key <path> to your registered Aspera private "
+                    "key, or use the default HTTP transport."
+                )
+        elif password:
+            env["ASPERA_SCP_PASS"] = password
+        else:
             raise ValueError(
-                f"iProX Aspera key not found: {key_path}. Pass --aspera-key "
-                "<path> to your registered Aspera private key, or use the "
-                "default HTTP transport."
+                "iProX Aspera needs a credential: set IPROX_ASPERA_PASSWORD "
+                "(your iProX account password) or pass --aspera-key <path>. "
+                "HTTP is the default alternative."
             )
         ascp = cls._ascp_binary()
         remote_paths = [urlparse(u).path for u in urls]
@@ -109,7 +108,9 @@ class IproxProvider(Provider):
                     fh.write(path + "\n")
             argv = [
                 ascp, "-T", "-l", maximum_bandwidth, "-P", cls.ASPERA_PORT,
-                "-k", "1", "-i", key_path, "--mode", "recv",
+                "-k", "1",
+            ] + (["-i", key_path] if key_path else []) + [
+                "--mode", "recv",
                 "--host", cls.ASPERA_HOST, "--file-list", list_path,
                 "--user", user, output_folder,
             ]
@@ -118,7 +119,7 @@ class IproxProvider(Provider):
                 len(remote_paths),
             )
             try:
-                subprocess.run(argv, check=True)
+                subprocess.run(argv, check=True, env=env, stdin=subprocess.DEVNULL)
             except subprocess.CalledProcessError as e:
                 raise RuntimeError(
                     f"iProX Aspera transfer failed (exit {e.returncode})"

--- a/pridepy/download/iprox.py
+++ b/pridepy/download/iprox.py
@@ -55,6 +55,20 @@ class IproxProvider(Provider):
         from pridepy.download.pride import PrideProvider
         return PrideProvider.get_ascp_binary()
 
+    @staticmethod
+    def _default_aspera_key() -> str:
+        """Path to the public Aspera key bundled with pridepy.
+
+        iProX accepts the standard public Aspera key, so Aspera works with
+        no key setup: users only supply ``--iprox-user``. ``--aspera-key``
+        overrides this when a site requires a different registered key.
+        """
+        import importlib.resources
+        key = importlib.resources.files("pridepy").joinpath(
+            "aspera/key/asperaweb_id_dsa.openssh"
+        )
+        return os.path.abspath(key)
+
     @classmethod
     def aspera_download(
         cls,
@@ -77,11 +91,13 @@ class IproxProvider(Provider):
                 "iProX Aspera requires --iprox-user (your registered iProX "
                 "username)."
             )
-        if not key_path or not os.path.isfile(key_path):
+        if not key_path:
+            key_path = cls._default_aspera_key()
+        if not os.path.isfile(key_path):
             raise ValueError(
-                "iProX Aspera requires --aspera-key <path> (the path to your "
-                "registered Aspera private key). HTTP is the default "
-                "alternative if you don't have one."
+                f"iProX Aspera key not found: {key_path}. Pass --aspera-key "
+                "<path> to your registered Aspera private key, or use the "
+                "default HTTP transport."
             )
         ascp = cls._ascp_binary()
         remote_paths = [urlparse(u).path for u in urls]

--- a/pridepy/download/proteomexchange.py
+++ b/pridepy/download/proteomexchange.py
@@ -30,7 +30,6 @@ from typing import ClassVar, Dict, List, Optional
 from urllib.parse import urlparse
 
 from pridepy.download.base import Provider
-from pridepy.download.util import flatten_relative_paths
 from pridepy.util.api_handling import Util
 
 
@@ -175,7 +174,7 @@ class ProteomeXchangeProvider(Provider):
         download_threads: int = 1,
         protocol: str = "ftp",
         iprox_user: Optional[str] = None,
-        iprox_password: Optional[str] = None,
+        aspera_key: Optional[str] = None,
     ) -> None:
         """End-to-end: resolve XML, list files, partition by scheme, download.
 
@@ -189,7 +188,8 @@ class ProteomeXchangeProvider(Provider):
 
         When ``protocol == "aspera"``, iProX-hosted files are routed through
         :meth:`IproxProvider.aspera_download` instead of the HTTP/FTP path
-        (opt-in, requires ``iprox_user``/``iprox_password``).
+        (opt-in, requires ``iprox_user``/``aspera_key``; key-based auth only,
+        and the transfer always preserves the source directory tree).
         """
         records = self.list_files(px_id_or_url)
         if not records:
@@ -198,13 +198,12 @@ class ProteomeXchangeProvider(Provider):
 
         if protocol.lower() == "aspera":
             from pridepy.download.iprox import IproxProvider
-            iprox_urls, rels = [], []
+            iprox_urls = []
             for r in records:
                 loc = self.get_download_url(r, protocol)
                 host = (urlparse(loc).hostname or "").lower()
                 if host == "download.iprox.org":
                     iprox_urls.append(loc)
-                    rels.append(r.get("relativePath"))
             if not iprox_urls:
                 raise ValueError(
                     "Aspera requested but no iProX-hosted files found in this dataset."
@@ -218,22 +217,11 @@ class ProteomeXchangeProvider(Provider):
                     len(records) - len(iprox_urls),
                     len(records),
                 )
-            if flatten:
-                sources = [
-                    rel if rel else urlparse(url).path
-                    for url, rel in zip(iprox_urls, rels)
-                ]
-                dest_rels: List[Optional[str]] = flatten_relative_paths(sources)
-            else:
-                dest_rels = rels
             IproxProvider.aspera_download(
                 urls=iprox_urls,
                 output_folder=output_folder,
-                relative_paths=dest_rels,
                 user=iprox_user,
-                password=iprox_password,
-                skip_if_downloaded_already=skip_if_downloaded_already,
-                parallel_files=parallel_files,
+                key_path=aspera_key,
             )
             return
 

--- a/pridepy/download/proteomexchange.py
+++ b/pridepy/download/proteomexchange.py
@@ -175,6 +175,7 @@ class ProteomeXchangeProvider(Provider):
         protocol: str = "ftp",
         iprox_user: Optional[str] = None,
         aspera_key: Optional[str] = None,
+        aspera_password: Optional[str] = None,
     ) -> None:
         """End-to-end: resolve XML, list files, partition by scheme, download.
 
@@ -188,8 +189,9 @@ class ProteomeXchangeProvider(Provider):
 
         When ``protocol == "aspera"``, iProX-hosted files are routed through
         :meth:`IproxProvider.aspera_download` instead of the HTTP/FTP path
-        (opt-in, requires ``iprox_user``/``aspera_key``; key-based auth only,
-        and the transfer always preserves the source directory tree).
+        (opt-in, requires ``iprox_user`` plus either ``aspera_key`` or
+        ``aspera_password``; the transfer always preserves the source
+        directory tree).
         """
         records = self.list_files(px_id_or_url)
         if not records:
@@ -222,6 +224,7 @@ class ProteomeXchangeProvider(Provider):
                 output_folder=output_folder,
                 user=iprox_user,
                 key_path=aspera_key,
+                password=aspera_password,
             )
             return
 

--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import asyncio
 import logging
+import os
+import sys
 from typing import Optional
 
 import click
@@ -403,10 +405,9 @@ def download_file_by_name(
     envvar="IPROX_ASPERA_KEY",
     default=None,
     type=str,
-    help="Path to an Aspera private key for iProX (optional; only with "
-    "--protocol aspera). Defaults to the public Aspera key bundled with "
-    "pridepy, so normally you only need --iprox-user. Override this if your "
-    "site requires a specific registered key.",
+    help="Optional Aspera private key for iProX (only with --protocol "
+    "aspera). If omitted, password auth is used via the "
+    "IPROX_ASPERA_PASSWORD env var or a secure prompt.",
 )
 def download_px_raw_files(
     accession: str,
@@ -423,6 +424,10 @@ def download_px_raw_files(
     files = Files()
     logging.info(f"PX accession/URL: {accession}")
 
+    aspera_password = os.environ.get("IPROX_ASPERA_PASSWORD")
+    if protocol.lower() == "aspera" and not aspera_key and not aspera_password and sys.stdin.isatty():
+        aspera_password = click.prompt("iProX Aspera password", hide_input=True)
+
     files.download_px_raw_files(
         accession,
         output_folder,
@@ -433,6 +438,7 @@ def download_px_raw_files(
         parallel_files=parallel_files,
         iprox_user=iprox_user,
         aspera_key=aspera_key,
+        aspera_password=aspera_password,
     )
 
 

--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -403,9 +403,10 @@ def download_file_by_name(
     envvar="IPROX_ASPERA_KEY",
     default=None,
     type=str,
-    help="Path to your Aspera private key for iProX (required with "
-    "--protocol aspera; the key you registered when setting up your "
-    "Aspera client).",
+    help="Path to an Aspera private key for iProX (optional; only with "
+    "--protocol aspera). Defaults to the public Aspera key bundled with "
+    "pridepy, so normally you only need --iprox-user. Override this if your "
+    "site requires a specific registered key.",
 )
 def download_px_raw_files(
     accession: str,

--- a/pridepy/pridepy.py
+++ b/pridepy/pridepy.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import asyncio
 import logging
-import os
 from typing import Optional
 
 import click
@@ -396,10 +395,17 @@ def download_file_by_name(
     envvar="IPROX_USER",
     default=None,
     type=str,
-    help="iProX account username. Only used with --protocol aspera. The "
-    "password is never accepted as a command-line flag: it is read from "
-    "the IPROX_ASPERA_PASSWORD environment variable, or prompted for "
-    "securely (hidden input) if not set.",
+    help="Your registered iProX username. Required with --protocol aspera.",
+)
+@click.option(
+    "--aspera-key",
+    "aspera_key",
+    envvar="IPROX_ASPERA_KEY",
+    default=None,
+    type=str,
+    help="Path to your Aspera private key for iProX (required with "
+    "--protocol aspera; the key you registered when setting up your "
+    "Aspera client).",
 )
 def download_px_raw_files(
     accession: str,
@@ -410,14 +416,11 @@ def download_px_raw_files(
     parallel_files: int = 1,
     preserve_structure: bool = False,
     iprox_user: Optional[str] = None,
+    aspera_key: Optional[str] = None,
 ):
     """CLI wrapper to download raw files via ProteomeXchange XML."""
     files = Files()
     logging.info(f"PX accession/URL: {accession}")
-
-    password = os.environ.get("IPROX_ASPERA_PASSWORD")
-    if protocol.lower() == "aspera" and not password:
-        password = click.prompt("iProX Aspera password", hide_input=True)
 
     files.download_px_raw_files(
         accession,
@@ -428,7 +431,7 @@ def download_px_raw_files(
         download_threads=download_threads,
         parallel_files=parallel_files,
         iprox_user=iprox_user,
-        iprox_password=password,
+        aspera_key=aspera_key,
     )
 
 

--- a/pridepy/tests/test_iprox_aspera.py
+++ b/pridepy/tests/test_iprox_aspera.py
@@ -1,4 +1,4 @@
-"""iProX Aspera command construction + key-auth handling."""
+"""iProX Aspera command construction + credential handling."""
 import os
 import re
 import subprocess
@@ -60,16 +60,53 @@ class TestIproxAspera(TestCase):
         assert argv[argv.index("--user") + 1] == "daicx"
         assert argv[-1] == output_folder
 
-        # no password/env credential handling at all
-        assert "env" not in kwargs
+        # key-based auth: no ASPERA_SCP_PASS set in the subprocess env
+        assert "ASPERA_SCP_PASS" not in kwargs.get("env", {})
         assert "ASPERA_SCP_PASS" not in argv
         assert not any("secret" in str(a) for a in argv)
+
+        # stdin is always closed so a rejected/missing credential errors
+        # instead of blocking on an interactive Password: prompt
+        assert kwargs.get("stdin") == subprocess.DEVNULL
 
         # file-list contains exactly the URL paths, one per line
         assert captured_list_contents["lines"] == [
             "/IPX0003474000/IPX0003474001/a.raw",
             "/IPX0002031000/IPX0002031001/b.raw",
         ]
+
+    def test_builds_ascp_password_based_file_list_argv(self):
+        urls = ["http://download.iprox.org/IPX0003474000/IPX0003474001/a.raw"]
+
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch("pridepy.download.iprox.subprocess.run") as run, \
+             patch.object(IproxProvider, "_ascp_binary", return_value="/bin/ascp"):
+            run.return_value = MagicMock(returncode=0)
+            output_folder = os.path.join(tmp, "out")
+            IproxProvider.aspera_download(
+                urls=urls,
+                output_folder=output_folder,
+                user="daicx",
+                password="secret",
+                maximum_bandwidth="500M",
+            )
+
+        args, kwargs = run.call_args
+        argv = args[0]
+
+        # password auth: no -i flag at all
+        assert "-i" not in argv
+        assert argv[argv.index("--mode") + 1] == "recv"
+        assert argv[argv.index("--host") + 1] == "download.iprox.org"
+        assert argv[argv.index("--user") + 1] == "daicx"
+        assert argv[-1] == output_folder
+
+        # credential goes through the env, never on argv
+        assert kwargs.get("env", {}).get("ASPERA_SCP_PASS") == "secret"
+        assert not any("secret" in str(a) for a in argv)
+
+        # stdin closed so ascp can't fall back to an interactive prompt
+        assert kwargs.get("stdin") == subprocess.DEVNULL
 
     def test_temp_file_list_is_removed_after_run(self):
         url = "http://download.iprox.org/IPX0003578000/IPX0003578001/a.raw"
@@ -102,23 +139,17 @@ class TestIproxAspera(TestCase):
                     key_path=key_path,
                 )
 
-    def test_missing_key_defaults_to_bundled_key(self):
-        """key_path=None falls back to pridepy's bundled Aspera key, so
-        Aspera needs no key setup — only --iprox-user."""
-        with tempfile.TemporaryDirectory() as tmp:
-            with patch("pridepy.download.iprox.subprocess.run") as run, \
-                 patch.object(IproxProvider, "_ascp_binary", return_value="/bin/ascp"):
-                run.return_value = MagicMock(returncode=0)
+    def test_missing_credential_raises(self):
+        """Neither key nor password supplied: fail fast, never call ascp."""
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch("pridepy.download.iprox.subprocess.run") as run:
+            with pytest.raises(ValueError, match="IPROX_ASPERA_PASSWORD"):
                 IproxProvider.aspera_download(
                     urls=["http://download.iprox.org/IPX1/a.raw"],
-                    output_folder=tmp,
+                    output_folder=os.path.join(tmp, "out"),
                     user="daicx",
-                    key_path=None,
                 )
-            argv = run.call_args.args[0]
-            key_used = argv[argv.index("-i") + 1]
-            assert key_used.endswith("aspera/key/asperaweb_id_dsa.openssh")
-            assert os.path.isfile(key_used)
+            run.assert_not_called()
 
     def test_nonexistent_key_path_raises(self):
         with pytest.raises(ValueError, match="--aspera-key"):
@@ -146,7 +177,7 @@ class TestIproxAspera(TestCase):
 
 
 class TestPxAsperaRouting(TestCase):
-    def test_px_aspera_routes_to_iprox(self):
+    def test_px_aspera_routes_to_iprox_with_key(self):
         from pridepy.download.proteomexchange import ProteomeXchangeProvider
         prov = ProteomeXchangeProvider()
         rec = {
@@ -167,6 +198,28 @@ class TestPxAsperaRouting(TestCase):
             asp.assert_called_once()
             assert asp.call_args.kwargs["user"] == "daicx"
             assert asp.call_args.kwargs["key_path"] == key_path
+            assert asp.call_args.kwargs["password"] is None
+
+    def test_px_aspera_routes_to_iprox_with_password(self):
+        from pridepy.download.proteomexchange import ProteomeXchangeProvider
+        prov = ProteomeXchangeProvider()
+        rec = {
+            "publicFileLocations": [
+                {"name": "FTP Protocol",
+                 "value": "http://download.iprox.org/IPX1/IPX2/a.raw"}
+            ],
+            "relativePath": "IPX2/a.raw",
+        }
+        with patch.object(prov, "list_files", return_value=[rec]), \
+             patch("pridepy.download.iprox.IproxProvider.aspera_download") as asp:
+            prov.download_from_accession_or_url(
+                "PXD000001", "/tmp/x", protocol="aspera",
+                iprox_user="daicx", aspera_password="secret",
+            )
+        asp.assert_called_once()
+        assert asp.call_args.kwargs["user"] == "daicx"
+        assert asp.call_args.kwargs["key_path"] is None
+        assert asp.call_args.kwargs["password"] == "secret"
 
     def test_px_aspera_rejects_spoofed_host(self):
         """A URL on a lookalike host (substring match, not exact) must NOT be

--- a/pridepy/tests/test_iprox_aspera.py
+++ b/pridepy/tests/test_iprox_aspera.py
@@ -102,14 +102,23 @@ class TestIproxAspera(TestCase):
                     key_path=key_path,
                 )
 
-    def test_missing_key_raises(self):
-        with pytest.raises(ValueError, match="--aspera-key"):
-            IproxProvider.aspera_download(
-                urls=["http://download.iprox.org/IPX1/a.raw"],
-                output_folder="/tmp/x",
-                user="daicx",
-                key_path=None,
-            )
+    def test_missing_key_defaults_to_bundled_key(self):
+        """key_path=None falls back to pridepy's bundled Aspera key, so
+        Aspera needs no key setup — only --iprox-user."""
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("pridepy.download.iprox.subprocess.run") as run, \
+                 patch.object(IproxProvider, "_ascp_binary", return_value="/bin/ascp"):
+                run.return_value = MagicMock(returncode=0)
+                IproxProvider.aspera_download(
+                    urls=["http://download.iprox.org/IPX1/a.raw"],
+                    output_folder=tmp,
+                    user="daicx",
+                    key_path=None,
+                )
+            argv = run.call_args.args[0]
+            key_used = argv[argv.index("-i") + 1]
+            assert key_used.endswith("aspera/key/asperaweb_id_dsa.openssh")
+            assert os.path.isfile(key_used)
 
     def test_nonexistent_key_path_raises(self):
         with pytest.raises(ValueError, match="--aspera-key"):

--- a/pridepy/tests/test_iprox_aspera.py
+++ b/pridepy/tests/test_iprox_aspera.py
@@ -1,4 +1,4 @@
-"""iProX Aspera command construction + credential handling."""
+"""iProX Aspera command construction + key-auth handling."""
 import os
 import re
 import subprocess
@@ -11,38 +11,113 @@ import pytest
 from pridepy.download.iprox import IproxProvider
 
 
+def _make_key_file(tmp):
+    key_path = os.path.join(tmp, "aspera.key")
+    with open(key_path, "w") as f:
+        f.write("fake-private-key")
+    return key_path
+
+
 class TestIproxAspera(TestCase):
-    def test_builds_ascp_source_and_env(self):
-        url = "http://download.iprox.org/IPX0003578000/IPX0003578001/a.raw"
+    def test_builds_ascp_key_based_file_list_argv(self):
+        urls = [
+            "http://download.iprox.org/IPX0003474000/IPX0003474001/a.raw",
+            "http://download.iprox.org/IPX0002031000/IPX0002031001/b.raw",
+        ]
+        captured_list_contents = {}
+
+        def fake_run(argv, **kwargs):
+            list_idx = argv.index("--file-list") + 1
+            list_path = argv[list_idx]
+            with open(list_path) as f:
+                captured_list_contents["lines"] = f.read().splitlines()
+            return MagicMock(returncode=0)
+
         with tempfile.TemporaryDirectory() as tmp, \
-             patch("pridepy.download.iprox.subprocess.run") as run, \
+             patch("pridepy.download.iprox.subprocess.run", side_effect=fake_run) as run, \
              patch.object(IproxProvider, "_ascp_binary", return_value="/bin/ascp"):
-            run.return_value = MagicMock(returncode=0)
+            key_path = _make_key_file(tmp)
+            output_folder = os.path.join(tmp, "out")
             IproxProvider.aspera_download(
-                urls=[url],
-                output_folder=tmp,
-                relative_paths=["IPX0003578001/a.raw"],
-                user="bob",
-                password="secret",
-                maximum_bandwidth="100M",
+                urls=urls,
+                output_folder=output_folder,
+                user="daicx",
+                key_path=key_path,
+                maximum_bandwidth="500M",
             )
+
         args, kwargs = run.call_args
         argv = args[0]
-        assert argv[0] == "/bin/ascp"
-        assert "33001" in argv
-        assert "bob@download.iprox.org:/data/iprox/IPX0003578000/IPX0003578001/a.raw" in argv
-        # password only via env, never argv
-        assert "secret" not in argv
-        assert kwargs["env"]["ASPERA_SCP_PASS"] == "secret"
 
-    def test_missing_credentials_raises(self):
-        with pytest.raises(ValueError, match="credentials"):
+        assert argv[0] == "/bin/ascp"
+        assert "-T" in argv
+        assert argv[argv.index("-l") + 1] == "500M"
+        assert argv[argv.index("-P") + 1] == "33001"
+        assert argv[argv.index("-k") + 1] == "1"
+        assert argv[argv.index("-i") + 1] == key_path
+        assert argv[argv.index("--mode") + 1] == "recv"
+        assert argv[argv.index("--host") + 1] == "download.iprox.org"
+        assert argv[argv.index("--user") + 1] == "daicx"
+        assert argv[-1] == output_folder
+
+        # no password/env credential handling at all
+        assert "env" not in kwargs
+        assert "ASPERA_SCP_PASS" not in argv
+        assert not any("secret" in str(a) for a in argv)
+
+        # file-list contains exactly the URL paths, one per line
+        assert captured_list_contents["lines"] == [
+            "/IPX0003474000/IPX0003474001/a.raw",
+            "/IPX0002031000/IPX0002031001/b.raw",
+        ]
+
+    def test_temp_file_list_is_removed_after_run(self):
+        url = "http://download.iprox.org/IPX0003578000/IPX0003578001/a.raw"
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["list_path"] = argv[argv.index("--file-list") + 1]
+            return MagicMock(returncode=0)
+
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch("pridepy.download.iprox.subprocess.run", side_effect=fake_run), \
+             patch.object(IproxProvider, "_ascp_binary", return_value="/bin/ascp"):
+            key_path = _make_key_file(tmp)
+            IproxProvider.aspera_download(
+                urls=[url],
+                output_folder=os.path.join(tmp, "out"),
+                user="daicx",
+                key_path=key_path,
+            )
+        assert not os.path.exists(captured["list_path"])
+
+    def test_missing_user_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            key_path = _make_key_file(tmp)
+            with pytest.raises(ValueError, match="--iprox-user"):
+                IproxProvider.aspera_download(
+                    urls=["http://download.iprox.org/IPX1/a.raw"],
+                    output_folder=os.path.join(tmp, "out"),
+                    user=None,
+                    key_path=key_path,
+                )
+
+    def test_missing_key_raises(self):
+        with pytest.raises(ValueError, match="--aspera-key"):
             IproxProvider.aspera_download(
                 urls=["http://download.iprox.org/IPX1/a.raw"],
                 output_folder="/tmp/x",
-                relative_paths=["a.raw"],
-                user=None,
-                password=None,
+                user="daicx",
+                key_path=None,
+            )
+
+    def test_nonexistent_key_path_raises(self):
+        with pytest.raises(ValueError, match="--aspera-key"):
+            IproxProvider.aspera_download(
+                urls=["http://download.iprox.org/IPX1/a.raw"],
+                output_folder="/tmp/x",
+                user="daicx",
+                key_path="/no/such/key/file",
             )
 
     def test_failed_transfer_raises_runtime_error(self):
@@ -50,130 +125,15 @@ class TestIproxAspera(TestCase):
         with tempfile.TemporaryDirectory() as tmp, \
              patch("pridepy.download.iprox.subprocess.run") as run, \
              patch.object(IproxProvider, "_ascp_binary", return_value="/bin/ascp"):
+            key_path = _make_key_file(tmp)
             run.side_effect = subprocess.CalledProcessError(1, ["ascp"])
-            with pytest.raises(RuntimeError, match=re.escape(url)):
+            with pytest.raises(RuntimeError, match=re.escape("exit 1")):
                 IproxProvider.aspera_download(
                     urls=[url],
-                    output_folder=tmp,
-                    relative_paths=["IPX0003578001/a.raw"],
-                    user="bob",
-                    password="secret",
-                    maximum_bandwidth="100M",
+                    output_folder=os.path.join(tmp, "out"),
+                    user="daicx",
+                    key_path=key_path,
                 )
-
-    def test_skip_if_downloaded_already_skips_existing_file(self):
-        url = "http://download.iprox.org/IPX0003578000/IPX0003578001/a.raw"
-        with tempfile.TemporaryDirectory() as tmp, \
-             patch("pridepy.download.iprox.subprocess.run") as run, \
-             patch.object(IproxProvider, "_ascp_binary", return_value="/bin/ascp"):
-            dest_dir = os.path.join(tmp, "IPX0003578001")
-            os.makedirs(dest_dir, exist_ok=True)
-            dest_file = os.path.join(dest_dir, "a.raw")
-            with open(dest_file, "w") as f:
-                f.write("already here")
-
-            IproxProvider.aspera_download(
-                urls=[url],
-                output_folder=tmp,
-                relative_paths=["IPX0003578001/a.raw"],
-                user="bob",
-                password="secret",
-                maximum_bandwidth="100M",
-                skip_if_downloaded_already=True,
-            )
-        run.assert_not_called()
-
-    def test_skip_if_downloaded_already_does_not_skip_when_only_dir_exists(self):
-        """Regression: when relpath is missing, dest used to resolve to the
-        output DIRECTORY, so os.path.exists(dest) was always True and every
-        such file was wrongly skipped."""
-        url = "http://download.iprox.org/IPX0003578000/a.raw"
-        with tempfile.TemporaryDirectory() as tmp, \
-             patch("pridepy.download.iprox.subprocess.run") as run, \
-             patch.object(IproxProvider, "_ascp_binary", return_value="/bin/ascp"):
-            run.return_value = MagicMock(returncode=0)
-            IproxProvider.aspera_download(
-                urls=[url],
-                output_folder=tmp,
-                relative_paths=[None],
-                user="bob",
-                password="secret",
-                maximum_bandwidth="100M",
-                skip_if_downloaded_already=True,
-            )
-        run.assert_called_once()
-
-    def test_skip_if_downloaded_already_does_not_skip_zero_byte_file(self):
-        url = "http://download.iprox.org/IPX0003578000/IPX0003578001/a.raw"
-        with tempfile.TemporaryDirectory() as tmp, \
-             patch("pridepy.download.iprox.subprocess.run") as run, \
-             patch.object(IproxProvider, "_ascp_binary", return_value="/bin/ascp"):
-            dest_dir = os.path.join(tmp, "IPX0003578001")
-            os.makedirs(dest_dir, exist_ok=True)
-            dest_file = os.path.join(dest_dir, "a.raw")
-            open(dest_file, "w").close()  # 0-byte partial file
-            run.return_value = MagicMock(returncode=0)
-
-            IproxProvider.aspera_download(
-                urls=[url],
-                output_folder=tmp,
-                relative_paths=["IPX0003578001/a.raw"],
-                user="bob",
-                password="secret",
-                maximum_bandwidth="100M",
-                skip_if_downloaded_already=True,
-            )
-        run.assert_called_once()
-
-    def test_traversal_relpath_does_not_escape_output_folder(self):
-        """A relativePath like '../../etc/x' must not write outside output_folder."""
-        url = "http://download.iprox.org/IPX0003578000/a.raw"
-        with tempfile.TemporaryDirectory() as tmp, \
-             patch("pridepy.download.iprox.subprocess.run") as run, \
-             patch.object(IproxProvider, "_ascp_binary", return_value="/bin/ascp"):
-            run.return_value = MagicMock(returncode=0)
-            IproxProvider.aspera_download(
-                urls=[url],
-                output_folder=tmp,
-                relative_paths=["../../etc/x"],
-                user="bob",
-                password="secret",
-                maximum_bandwidth="100M",
-            )
-        args, kwargs = run.call_args
-        argv = args[0]
-        dest = argv[-1]
-        out_abs = os.path.abspath(tmp)
-        dest_abs = os.path.abspath(dest)
-        assert dest_abs == out_abs or dest_abs.startswith(out_abs + os.sep)
-
-    def test_parallel_files_downloads_all_and_aggregates_failures(self):
-        urls = [
-            "http://download.iprox.org/IPX0003578000/a.raw",
-            "http://download.iprox.org/IPX0003578000/b.raw",
-            "http://download.iprox.org/IPX0003578000/c.raw",
-        ]
-        rels = ["a.raw", "b.raw", "c.raw"]
-
-        def fake_run(argv, check, env):
-            if argv[-1].endswith("b.raw"):
-                raise subprocess.CalledProcessError(1, argv)
-            return MagicMock(returncode=0)
-
-        with tempfile.TemporaryDirectory() as tmp, \
-             patch("pridepy.download.iprox.subprocess.run", side_effect=fake_run) as run, \
-             patch.object(IproxProvider, "_ascp_binary", return_value="/bin/ascp"):
-            with pytest.raises(RuntimeError, match="b.raw"):
-                IproxProvider.aspera_download(
-                    urls=urls,
-                    output_folder=tmp,
-                    relative_paths=rels,
-                    user="bob",
-                    password="secret",
-                    maximum_bandwidth="100M",
-                    parallel_files=2,
-                )
-        assert run.call_count == 3
 
 
 class TestPxAsperaRouting(TestCase):
@@ -187,14 +147,17 @@ class TestPxAsperaRouting(TestCase):
             ],
             "relativePath": "IPX2/a.raw",
         }
-        with patch.object(prov, "list_files", return_value=[rec]), \
-             patch("pridepy.download.iprox.IproxProvider.aspera_download") as asp:
-            prov.download_from_accession_or_url(
-                "PXD000001", "/tmp/x", protocol="aspera",
-                iprox_user="bob", iprox_password="secret",
-            )
-        asp.assert_called_once()
-        assert asp.call_args.kwargs["user"] == "bob"
+        with tempfile.TemporaryDirectory() as tmp:
+            key_path = _make_key_file(tmp)
+            with patch.object(prov, "list_files", return_value=[rec]), \
+                 patch("pridepy.download.iprox.IproxProvider.aspera_download") as asp:
+                prov.download_from_accession_or_url(
+                    "PXD000001", "/tmp/x", protocol="aspera",
+                    iprox_user="daicx", aspera_key=key_path,
+                )
+            asp.assert_called_once()
+            assert asp.call_args.kwargs["user"] == "daicx"
+            assert asp.call_args.kwargs["key_path"] == key_path
 
     def test_px_aspera_rejects_spoofed_host(self):
         """A URL on a lookalike host (substring match, not exact) must NOT be
@@ -213,7 +176,7 @@ class TestPxAsperaRouting(TestCase):
             with pytest.raises(ValueError, match="no iProX-hosted files"):
                 prov.download_from_accession_or_url(
                     "PXD000001", "/tmp/x", protocol="aspera",
-                    iprox_user="bob", iprox_password="secret",
+                    iprox_user="daicx", aspera_key="/some/key",
                 )
         asp.assert_not_called()
 
@@ -243,58 +206,7 @@ class TestPxAsperaRouting(TestCase):
              self.assertLogs(level="WARNING") as log_ctx:
             prov.download_from_accession_or_url(
                 "PXD000001", "/tmp/x", protocol="aspera",
-                iprox_user="bob", iprox_password="secret",
+                iprox_user="daicx", aspera_key="/some/key",
             )
         asp.assert_called_once()
         assert any("not" in m.lower() and "iprox" in m.lower() for m in log_ctx.output)
-
-    def test_px_aspera_flattens_relative_paths_by_default(self):
-        """Aspera branch should honor flatten=True like the HTTP/FTP path:
-        dataset subtree paths collapse to deduplicated basenames."""
-        from pridepy.download.proteomexchange import ProteomeXchangeProvider
-        prov = ProteomeXchangeProvider()
-        records = [
-            {
-                "publicFileLocations": [
-                    {"name": "FTP Protocol",
-                     "value": "http://download.iprox.org/IPX1/run1/a.raw"}
-                ],
-                "relativePath": "run1/a.raw",
-            },
-            {
-                "publicFileLocations": [
-                    {"name": "FTP Protocol",
-                     "value": "http://download.iprox.org/IPX1/run2/a.raw"}
-                ],
-                "relativePath": "run2/a.raw",
-            },
-        ]
-        with patch.object(prov, "list_files", return_value=records), \
-             patch("pridepy.download.iprox.IproxProvider.aspera_download") as asp:
-            prov.download_from_accession_or_url(
-                "PXD000001", "/tmp/x", protocol="aspera", flatten=True,
-                iprox_user="bob", iprox_password="secret",
-            )
-        asp.assert_called_once()
-        rels = asp.call_args.kwargs["relative_paths"]
-        # Flattened + de-duped basenames, no subdirectories preserved.
-        assert set(rels) == {"a.raw", "a_1.raw"}
-
-    def test_px_aspera_preserves_structure_when_not_flattened(self):
-        from pridepy.download.proteomexchange import ProteomeXchangeProvider
-        prov = ProteomeXchangeProvider()
-        rec = {
-            "publicFileLocations": [
-                {"name": "FTP Protocol",
-                 "value": "http://download.iprox.org/IPX1/IPX2/a.raw"}
-            ],
-            "relativePath": "IPX2/a.raw",
-        }
-        with patch.object(prov, "list_files", return_value=[rec]), \
-             patch("pridepy.download.iprox.IproxProvider.aspera_download") as asp:
-            prov.download_from_accession_or_url(
-                "PXD000001", "/tmp/x", protocol="aspera", flatten=False,
-                iprox_user="bob", iprox_password="secret",
-            )
-        asp.assert_called_once()
-        assert asp.call_args.kwargs["relative_paths"] == ["IPX2/a.raw"]


### PR DESCRIPTION
## Why

The iProX Aspera support merged in #115 didn't work: it authenticated with a password via `ASPERA_SCP_PASS` **and** used the `user@host:/data/iprox/<path> dest` form, one `ascp` per file — iProX rejects that. A verified-working manual invocation is the batched `--file-list` / `--mode recv --host --user` form:

```
ascp -T -l 500M -P33001 -k 1 [-i <key>] --mode recv --host download.iprox.org --file-list file_list.txt --user <user> <dest>
```

where each file-list line is the remote path == `urlparse(url).path` of our records, e.g. `/IPX0003474000/IPX0003474001/<file>.raw` (no `/data/iprox` prefix). **The invocation form was the bug**, not the auth method — password auth works fine with this form (confirmed end-to-end against `download.iprox.org`).

## What changed

- **`IproxProvider.aspera_download` rewritten** to the working batched `--file-list` form (one `ascp` session for the whole dataset; FASP parallelizes internally). Temp file-list always cleaned up.
- **Auth (fail-fast, no hang):**
  - Default **password** via the `IPROX_ASPERA_PASSWORD` env var (→ `ASPERA_SCP_PASS`), or a hidden interactive prompt when on a TTY. No plaintext password CLI flag (per the earlier security review).
  - **`--aspera-key <path>`** optional alternative (`-i key`) for users with a registered key.
  - If neither credential is available in a non-interactive run → clear `ValueError` (does **not** fall through to `ascp`'s interactive `Password:` prompt).
- **`ascp` runs with `stdin=subprocess.DEVNULL`** so a missing/rejected credential errors immediately instead of blocking on `Password:` — critical for sbatch jobs.
- Password never appears on argv; not logged.
- Note: `ascp --file-list` recreates the `/IPX…/IPX…/` tree under the output dir, so the Aspera path **preserves structure** (flatten N/A) — documented.

## Usage

```bash
# password auth via env — safe for sbatch (no prompt, no hang)
IPROX_ASPERA_PASSWORD=... pridepy download-px-raw-files -a PXD077178 -o ./out \
  --protocol aspera --iprox-user <user>

# or a registered Aspera key
pridepy download-px-raw-files -a PXD077178 -o ./out \
  --protocol aspera --iprox-user <user> --aspera-key /path/to/key
```

Interactively (TTY), if `IPROX_ASPERA_PASSWORD` isn't set you're prompted (hidden). In batch you must set the env var (or use `--aspera-key`) or it errors fast. HTTP parallel (`-w`) remains the account-free default.

## Tests

`test_iprox_aspera.py`: both auth modes (key → `-i`, no `ASPERA_SCP_PASS`; password → `ASPERA_SCP_PASS` set, no `-i`, password never on argv), `stdin=DEVNULL` asserted, missing-credential → `ValueError` (ascp not called), missing-user / nonexistent-key errors, failed transfer → `RuntimeError`, file-list contents = URL paths, and PX aspera routing forwards key/password. Full suite: **167 passed, 4 skipped**.

## Verified

The batched form + password auth was confirmed working end-to-end against `download.iprox.org` (99-file dataset). The generic bundled Aspera key is **not** accepted by iProX, which is why password (or a site-registered key via `--aspera-key`) is the path here.
